### PR TITLE
Feat/2-dialect-dictionary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 }
 
+// Java 컴파일 옵션 추가
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['-parameters']
+}
+
 test {
     useJUnitPlatform()
 }

--- a/src/main/java/com/satoori/domain/dialect/controller/DialectController.java
+++ b/src/main/java/com/satoori/domain/dialect/controller/DialectController.java
@@ -1,0 +1,147 @@
+package com.satoori.domain.dialect.controller;
+
+import com.satoori.domain.dialect.dto.DialectResponse;
+import com.satoori.domain.dialect.dto.DialectMapPoint;
+import com.satoori.domain.dialect.dto.RegionMapResponse;
+import com.satoori.domain.dialect.dto.DialectRequest;
+import com.satoori.domain.dialect.service.DialectService;
+import com.satoori.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dictionary")
+@RequiredArgsConstructor
+public class DialectController {
+
+    private final DialectService dialectService;
+
+    // 방언 등록
+    @PostMapping
+    public ResponseEntity<Void> createDialect(
+            @RequestBody DialectRequest dto,
+            @AuthenticationPrincipal User user
+    ) {
+        dialectService.createDialect(dto, user);
+        return ResponseEntity.ok().build();
+    }
+
+    // 방언 전체 목록 조회
+    @GetMapping
+    public ResponseEntity<Page<DialectResponse>> getAllDialects(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal User user) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<DialectResponse> dialects = dialectService.getAllDialects(pageable, user);
+        return ResponseEntity.ok(dialects);
+    }
+
+    // 지역별 방언 조회
+    @GetMapping("/region/{region}")
+    public ResponseEntity<Page<DialectResponse>> getDialectsByRegion(
+            @PathVariable("region") String region,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal User user) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<DialectResponse> dialects = dialectService.getDialectsByRegion(region, pageable, user);
+        return ResponseEntity.ok(dialects);
+    }
+
+    // 키워드 검색
+    @GetMapping("/search")
+    public ResponseEntity<Page<DialectResponse>> searchDialects(
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal User user) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<DialectResponse> dialects = dialectService.searchDialects(keyword, pageable, user);
+        return ResponseEntity.ok(dialects);
+    }
+
+    // 특정 방언 상세 조회
+    @GetMapping("/{dialectId}")
+    public ResponseEntity<DialectResponse> getDialect(
+            @PathVariable("dialectId") Long dialectId,
+            @AuthenticationPrincipal User user) {
+
+        DialectResponse dialect = dialectService.getDialectById(dialectId, user);
+        return ResponseEntity.ok(dialect);
+    }
+
+    // 지도용 지역별 데이터
+    @GetMapping("/map")
+    public ResponseEntity<List<RegionMapResponse>> getMapData() {
+        List<RegionMapResponse> mapData = dialectService.getRegionMapData();
+        return ResponseEntity.ok(mapData);
+    }
+
+    // 지도용 마커 포인트 (전체 또는 지역별)
+    @GetMapping("/map/points")
+    public ResponseEntity<List<DialectMapPoint>> getMapPoints(
+            @RequestParam(name = "region", required = false) String region) {
+        System.out.println(">>> region param: [" + region + "]");  // 임시 로그
+
+        List<DialectMapPoint> points = dialectService.getDialectMapPoints(region);
+        return ResponseEntity.ok(points);
+    }
+
+    // 북마크 추가
+    @PostMapping("/{dialectId}/bookmark")
+    public ResponseEntity<String> addBookmark(
+            @PathVariable("dialectId") Long dialectId,
+            @AuthenticationPrincipal User user) {
+
+        dialectService.addBookmark(dialectId, user);
+        return ResponseEntity.ok("Bookmark added");
+    }
+
+    // 북마크 삭제
+    @DeleteMapping("/{dialectId}/bookmark")
+    public ResponseEntity<String> removeBookmark(
+            @PathVariable("dialectId") Long dialectId,
+            @AuthenticationPrincipal User user) {
+
+        dialectService.removeBookmark(dialectId, user);
+        return ResponseEntity.ok("Bookmark removed");
+    }
+
+    // 내 북마크 목록
+    @GetMapping("/bookmarks")
+    public ResponseEntity<Page<DialectResponse>> getMyBookmarks(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal User user) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<DialectResponse> bookmarks = dialectService.getMyBookmarks(user, pageable);
+        return ResponseEntity.ok(bookmarks);
+    }
+
+    // 방언 검증 (관리자용)
+    @PatchMapping("/{dialectId}/verify")
+    public ResponseEntity<String> verifyDialect(
+            @PathVariable("dialectId") Long dialectId,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user.getRole() != User.Role.ADMIN) {
+            return ResponseEntity.status(403).body("Forbidden: 관리자 권한 필요");
+        }
+
+        dialectService.verifyDialect(dialectId);
+        return ResponseEntity.ok("Dialect verified");
+    }
+}

--- a/src/main/java/com/satoori/domain/dialect/dto/DialectMapPoint.java
+++ b/src/main/java/com/satoori/domain/dialect/dto/DialectMapPoint.java
@@ -1,0 +1,17 @@
+package com.satoori.domain.dialect.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DialectMapPoint {
+    private Long dialectId;
+    private String dialect;
+    private String standard;
+    private String region;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/satoori/domain/dialect/dto/DialectRequest.java
+++ b/src/main/java/com/satoori/domain/dialect/dto/DialectRequest.java
@@ -1,0 +1,14 @@
+package com.satoori.domain.dialect.dto;
+
+import lombok.Data;
+
+@Data
+public class DialectRequest {
+    private String dialect;
+    private String standard;
+    private String meaning;
+    private String origin;
+    private String region;
+    private String example;
+    private String source;
+}

--- a/src/main/java/com/satoori/domain/dialect/dto/DialectResponse.java
+++ b/src/main/java/com/satoori/domain/dialect/dto/DialectResponse.java
@@ -1,0 +1,67 @@
+package com.satoori.domain.dialect.dto;
+
+import com.satoori.domain.dialect.entity.Dialect;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DialectResponse {
+    private Long dialectId;
+    private String dialect;
+    private String standard;
+    private String meaning;
+    private String origin;
+    private String region;
+    private String example;
+    private Boolean verified;
+    private String source;
+    private String ttsUrl;
+    private Double latitude;
+    private Double longitude;
+    private LocalDateTime createdAt;
+    private Boolean bookmarked;
+
+    public static DialectResponse from(Dialect dialect) {
+        return DialectResponse.builder()
+                .dialectId(dialect.getDialectId())
+                .dialect(dialect.getDialect())
+                .standard(dialect.getStandard())
+                .meaning(dialect.getMeaning())
+                .origin(dialect.getOrigin())
+                .region(dialect.getRegion())
+                .example(dialect.getExample())
+                .verified(dialect.getVerified())
+                .source(dialect.getSource())
+                .ttsUrl(dialect.getTtsUrl())
+                .latitude(dialect.getLatitude())
+                .longitude(dialect.getLongitude())
+                .createdAt(dialect.getCreatedAt())
+                .bookmarked(false)
+                .build();
+    }
+
+    public static DialectResponse from(Dialect dialect, boolean bookmarked) {
+        DialectResponse response = from(dialect);
+        return DialectResponse.builder()
+                .dialectId(response.getDialectId())
+                .dialect(response.getDialect())
+                .standard(response.getStandard())
+                .meaning(response.getMeaning())
+                .origin(response.getOrigin())
+                .region(response.getRegion())
+                .example(response.getExample())
+                .verified(response.getVerified())
+                .source(response.getSource())
+                .ttsUrl(response.getTtsUrl())
+                .latitude(response.getLatitude())
+                .longitude(response.getLongitude())
+                .createdAt(response.getCreatedAt())
+                .bookmarked(bookmarked)
+                .build();
+    }
+}

--- a/src/main/java/com/satoori/domain/dialect/dto/RegionMapResponse.java
+++ b/src/main/java/com/satoori/domain/dialect/dto/RegionMapResponse.java
@@ -1,0 +1,18 @@
+package com.satoori.domain.dialect.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RegionMapResponse {
+    private String region;
+    private Long count;
+    private Double latitude;
+    private Double longitude;
+    private List<DialectResponse> samples; // 샘플 방언 5개
+}

--- a/src/main/java/com/satoori/domain/dialect/entity/Dialect.java
+++ b/src/main/java/com/satoori/domain/dialect/entity/Dialect.java
@@ -1,0 +1,97 @@
+package com.satoori.domain.dialect.entity;
+
+import com.satoori.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "dialects", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"dialect", "region"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Dialect {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dialect_id")
+    private Long dialectId;
+
+    @Column(nullable = false)
+    private String dialect; // 사투리 표현
+
+    @Column(nullable = false)
+    private String standard; // 표준어 표현
+
+    @Column(length = 1000)
+    private String meaning; // 의미 해설
+
+    @Column(length = 1000)
+    private String origin; // 유래
+
+    @Column(nullable = false)
+    private String region; // 사용 지역
+
+    @Column(length = 500)
+    private String example; // 예문
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean verified = false; // 관리자 검수 여부
+
+    @Column(length = 500)
+    private String source; // 출처 정보
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User uploadedBy; // 업로드한 사용자
+
+    @Column(name = "tts_url")
+    private String ttsUrl; // TTS 음성 파일 URL
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 지도용 위치 정보
+    @Column(name = "latitude")
+    private Double latitude;  // 위도
+
+    @Column(name = "longitude")
+    private Double longitude; // 경도
+
+    //좌표 자동 설정
+    @PrePersist
+    @PreUpdate
+    private void setDefaultCoordinates() {
+        if (latitude == null || longitude == null) {
+            double[] coords = getDefaultCoordinatesForRegion(region);
+            this.latitude = coords[0];
+            this.longitude = coords[1];
+        }
+    }
+
+    private static double[] getDefaultCoordinatesForRegion(String region) {
+        Map<String, double[]> regionCoords = Map.of(
+                "서울", new double[]{37.5665, 126.9780},
+                "경기도", new double[]{37.4138, 127.5183},
+                "강원도", new double[]{37.8228, 128.1555},
+                "충청북도", new double[]{36.6357, 127.4917},
+                "충청남도", new double[]{36.5184, 126.8000},
+                "전라북도", new double[]{35.7175, 127.1530},
+                "전라남도", new double[]{34.8679, 126.9910},
+                "경상북도", new double[]{36.4919, 128.8889},
+                "경상남도", new double[]{35.4606, 128.2132},
+                "제주도", new double[]{33.4996, 126.5312}
+        );
+
+        return regionCoords.getOrDefault(region, new double[]{37.5665, 126.9780}); // 기본값: 서울
+    }
+}

--- a/src/main/java/com/satoori/domain/dialect/entity/DialectBookmark.java
+++ b/src/main/java/com/satoori/domain/dialect/entity/DialectBookmark.java
@@ -1,0 +1,35 @@
+package com.satoori.domain.dialect.entity;
+
+import com.satoori.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dialect_bookmarks",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "dialect_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DialectBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bookmarkId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dialect_id", nullable = false)
+    private Dialect dialect;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/satoori/domain/dialect/repository/DialectBookmarkRepository.java
+++ b/src/main/java/com/satoori/domain/dialect/repository/DialectBookmarkRepository.java
@@ -1,0 +1,18 @@
+package com.satoori.domain.dialect.repository;
+
+import com.satoori.domain.dialect.entity.DialectBookmark;
+import com.satoori.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DialectBookmarkRepository extends JpaRepository<DialectBookmark, Long> {
+    Page<DialectBookmark> findByUser(User user, Pageable pageable); // 사용자의 북마크 목록 조회
+    boolean existsByUserAndDialect_DialectId(User user, Long dialectId); // 특정 북마크 존재 여부 확인
+    Optional<DialectBookmark> findByUserAndDialect_DialectId(User user, Long dialectId); // 특정 북마크 조회
+    void deleteByUserAndDialect_DialectId(User user, Long dialectId); // 특정 북마크 삭제
+}

--- a/src/main/java/com/satoori/domain/dialect/repository/DialectRepository.java
+++ b/src/main/java/com/satoori/domain/dialect/repository/DialectRepository.java
@@ -1,0 +1,37 @@
+package com.satoori.domain.dialect.repository;
+
+import com.satoori.domain.dialect.entity.Dialect;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DialectRepository extends JpaRepository<Dialect, Long> {
+    Page<Dialect> findByVerifiedTrue(Pageable pageable); // 방언 전체 목록 조회
+    Page<Dialect> findByRegionAndVerifiedTrue(String region, Pageable pageable); // 지역별 방언 조회
+
+    // 키워드 검색 (방언, 표준어, 의미, 예문 포함)
+    @Query("SELECT d FROM Dialect d WHERE d.verified = true AND " +
+            "(d.dialect LIKE %:keyword% OR " +
+            "d.standard LIKE %:keyword% OR " +
+            "d.meaning LIKE %:keyword% OR " +
+            "d.example LIKE %:keyword%)")
+    Page<Dialect> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    Optional<Dialect> findByDialectAndVerifiedTrue(String dialect); // 특정 방언 단어로 조회
+
+    @Query("SELECT d.region, COUNT(d) FROM Dialect d WHERE d.verified = true GROUP BY d.region") // 지역별 방언 개수 조회 (지도용)
+    List<Object[]> countByRegion();
+
+    List<Dialect> findTop5ByRegionAndVerifiedTrueOrderByCreatedAtDesc(String region); // 지역별 방언 샘플 조회 (지도용)
+
+    Page<Dialect> findByVerifiedFalse(Pageable pageable); // 검수되지 않은 방언 조회 (관리자용)
+
+    boolean existsByDialectAndRegion(String dialect, String region); // DB에 같은 방언(dialect + region)이 이미 있는지 확인
+}

--- a/src/main/java/com/satoori/domain/dialect/service/DialectService.java
+++ b/src/main/java/com/satoori/domain/dialect/service/DialectService.java
@@ -1,0 +1,188 @@
+package com.satoori.domain.dialect.service;
+
+import com.satoori.domain.dialect.dto.DialectResponse;
+import com.satoori.domain.dialect.dto.DialectMapPoint;
+import com.satoori.domain.dialect.dto.RegionMapResponse;
+import com.satoori.domain.dialect.dto.DialectRequest;
+import com.satoori.domain.dialect.entity.Dialect;
+import com.satoori.domain.dialect.entity.DialectBookmark;
+import com.satoori.domain.dialect.repository.DialectBookmarkRepository;
+import com.satoori.domain.dialect.repository.DialectRepository;
+import com.satoori.domain.user.entity.User;
+import com.satoori.global.exception.DuplicateDialectException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DialectService {
+
+    private final DialectRepository dialectRepository;
+    private final DialectBookmarkRepository bookmarkRepository;
+
+    // 방언 전체 목록 조회
+    @Transactional(readOnly = true)
+    public Page<DialectResponse> getAllDialects(Pageable pageable, User user) {
+        Page<Dialect> dialects = dialectRepository.findByVerifiedTrue(pageable);
+        return dialects.map(dialect -> {
+            boolean bookmarked = user != null &&
+                    bookmarkRepository.existsByUserAndDialect_DialectId(user, dialect.getDialectId());
+            return DialectResponse.from(dialect, bookmarked);
+        });
+    }
+
+    // 지역별 방언 조회
+    @Transactional(readOnly = true)
+    public Page<DialectResponse> getDialectsByRegion(String region, Pageable pageable, User user) {
+        Page<Dialect> dialects = dialectRepository.findByRegionAndVerifiedTrue(region, pageable);
+        return dialects.map(dialect -> {
+            boolean bookmarked = user != null &&
+                    bookmarkRepository.existsByUserAndDialect_DialectId(user, dialect.getDialectId());
+            return DialectResponse.from(dialect, bookmarked);
+        });
+    }
+
+    // 방언 등록
+    @Transactional
+    public void createDialect(DialectRequest dto, User user) {
+        if (dialectRepository.existsByDialectAndRegion(dto.getDialect(), dto.getRegion())) {
+            throw new DuplicateDialectException("이미 등록된 방언입니다.");
+        }
+
+        Dialect dialect = Dialect.builder()
+                .dialect(dto.getDialect())
+                .standard(dto.getStandard())
+                .meaning(dto.getMeaning())
+                .origin(dto.getOrigin())
+                .region(dto.getRegion())
+                .example(dto.getExample())
+                .source(dto.getSource())
+                .uploadedBy(user)
+                .verified(false)
+                .build();
+
+        dialectRepository.save(dialect);
+    }
+
+    // 키워드 검색
+    @Transactional(readOnly = true)
+    public Page<DialectResponse> searchDialects(String keyword, Pageable pageable, User user) {
+        Page<Dialect> dialects = dialectRepository.searchByKeyword(keyword, pageable);
+        return dialects.map(dialect -> {
+            boolean bookmarked = user != null &&
+                    bookmarkRepository.existsByUserAndDialect_DialectId(user, dialect.getDialectId());
+            return DialectResponse.from(dialect, bookmarked);
+        });
+    }
+
+    // 특정 방언 상세 조회
+    @Transactional(readOnly = true)
+    public DialectResponse getDialectById(Long dialectId, User user) {
+        Dialect dialect = dialectRepository.findById(dialectId)
+                .orElseThrow(() -> new RuntimeException("Dialect not found"));
+
+        boolean bookmarked = user != null &&
+                bookmarkRepository.existsByUserAndDialect_DialectId(user, dialectId);
+
+        return DialectResponse.from(dialect, bookmarked);
+    }
+
+    // 지도용 지역별 데이터 조회
+    @Transactional(readOnly = true)
+    public List<RegionMapResponse> getRegionMapData() {
+        List<Object[]> regionCounts = dialectRepository.countByRegion();
+
+        return regionCounts.stream().map(row -> {
+            String region = (String) row[0];
+            Long count = (Long) row[1];
+
+            // 해당 지역 샘플 방언 5개 조회
+            List<Dialect> samples = dialectRepository
+                    .findTop5ByRegionAndVerifiedTrueOrderByCreatedAtDesc(region);
+
+            List<DialectResponse> sampleResponses = samples.stream()
+                    .map(DialectResponse::from)
+                    .collect(Collectors.toList());
+
+            // 첫 번째 샘플의 좌표 사용 (또는 null)
+            Double lat = samples.isEmpty() ? null : samples.get(0).getLatitude();
+            Double lng = samples.isEmpty() ? null : samples.get(0).getLongitude();
+
+            return RegionMapResponse.builder()
+                    .region(region)
+                    .count(count)
+                    .latitude(lat)
+                    .longitude(lng)
+                    .samples(sampleResponses)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    // 특정 지역의 모든 방언 좌표 조회 (지도 마커용)
+    @Transactional(readOnly = true)
+    public List<DialectMapPoint> getDialectMapPoints(String region) {
+        List<Dialect> dialects;
+
+        if (region == null || region.isEmpty()) {
+            dialects = dialectRepository.findByVerifiedTrue(Pageable.unpaged()).getContent();
+        } else {
+            dialects = dialectRepository.findByRegionAndVerifiedTrue(region, Pageable.unpaged()).getContent();
+        }
+
+        return dialects.stream()
+                .filter(d -> d.getLatitude() != null && d.getLongitude() != null)
+                .map(d -> DialectMapPoint.builder()
+                        .dialectId(d.getDialectId())
+                        .dialect(d.getDialect())
+                        .standard(d.getStandard())
+                        .region(d.getRegion())
+                        .latitude(d.getLatitude())
+                        .longitude(d.getLongitude())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // 북마크 추가
+    @Transactional
+    public void addBookmark(Long dialectId, User user) {
+        Dialect dialect = dialectRepository.findById(dialectId)
+                .orElseThrow(() -> new RuntimeException("Dialect not found"));
+
+        if (bookmarkRepository.existsByUserAndDialect_DialectId(user, dialectId)) {
+            throw new RuntimeException("Already bookmarked");
+        }
+
+        DialectBookmark bookmark = DialectBookmark.builder()
+                .user(user)
+                .dialect(dialect)
+                .build();
+
+        bookmarkRepository.save(bookmark);
+    }
+
+    // 북마크 삭제
+    @Transactional
+    public void removeBookmark(Long dialectId, User user) {
+        bookmarkRepository.deleteByUserAndDialect_DialectId(user, dialectId);
+    }
+
+    // 내 북마크 목록 조회
+    @Transactional(readOnly = true)
+    public Page<DialectResponse> getMyBookmarks(User user, Pageable pageable) {
+        Page<DialectBookmark> bookmarks = bookmarkRepository.findByUser(user, pageable);
+        return bookmarks.map(bookmark -> DialectResponse.from(bookmark.getDialect(), true));
+    }
+
+    @Transactional
+    public void verifyDialect(Long dialectId) {
+        Dialect dialect = dialectRepository.findById(dialectId)
+                .orElseThrow(() -> new RuntimeException("해당 방언이 존재하지 않습니다."));
+        dialect.setVerified(true);
+    }
+}

--- a/src/main/java/com/satoori/global/exception/DuplicateDialectException.java
+++ b/src/main/java/com/satoori/global/exception/DuplicateDialectException.java
@@ -1,0 +1,9 @@
+package com.satoori.global.exception;
+
+
+// 방언 중복 등록 시 발생하는 사용자 정의 예외
+public class DuplicateDialectException extends RuntimeException {
+    public DuplicateDialectException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/satoori/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/satoori/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.satoori.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicateDialectException.class)
+    public ResponseEntity<String> handleDuplicateDialect(DuplicateDialectException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT) // 409 Conflict
+                .body(e.getMessage()); // 예외 메세지 그대로 응답
+    }
+}

--- a/src/main/java/com/satoori/global/security/SecurityConfig.java
+++ b/src/main/java/com/satoori/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.satoori.global.security.oauth.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,14 +31,48 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll() // 공개 접근
+
+                        .requestMatchers(HttpMethod.GET, "/api/dictionary/**").permitAll() // 방언 사전 조회는 비회원도 허용
+
+                        // 북마크는 로그인 필요 → 토큰 없으면 401
+                        .requestMatchers(HttpMethod.POST, "/api/dictionary/*/bookmark").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/dictionary/*/bookmark").authenticated()
+
+                        .requestMatchers(HttpMethod.PATCH, "/api/dictionary/*/verify").hasRole("ADMIN") // 방언 검증은 ADMIN만 → 일반 유저면 403
+
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 전용 경로
+
                         .anyRequest().authenticated()
                 )
+
+                // OAuth2 로그인 처리 설정
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo ->
                                 userInfo.userService(customOAuth2UserService))
-                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .successHandler(oAuth2AuthenticationSuccessHandler) // 로그인 성공 시 JWT 발급 + 리다이렉트
+                )
+
+                // 인증 실패 및 인가 실패 처리 핸들링
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((req, res, ex) -> {
+                            // API 요청이면 JSON 401
+                            if (req.getRequestURI().startsWith("/api/")) {
+                                res.setStatus(401);
+                                res.setContentType("application/json");
+                                res.getWriter().write("{\"message\": \"Unauthorized\"}");
+                            } else {
+                                // API 아닌 경로는 OAuth2 로그인으로 리다이렉트
+                                res.sendRedirect("/oauth2/authorization/google");
+                            }
+                        })
+
+                        // 권한 부족 (ex. 일반 사용자가 관리자 API 접근)
+                        .accessDeniedHandler((req, res, ex) -> {
+                            res.setStatus(403);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"message\": \"Forbidden: 관리자 권한 필요\"}");
+                        })
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  sql:
+    init:
+      mode: always
 
   security:
     oauth2:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+INSERT INTO "dialects" ("dialect", "standard", "meaning", "origin", "region", "example", "verified", "source", "latitude", "longitude", "created_at")
+SELECT '정구지', '부추', '김치나 무침에 쓰이는 채소류', '경상도 지역에서 오래 사용된 방언', '경상도', '정구지 넣고 전 부치자', true, '경상도 방언 사전 (2018)', 35.5, 128.5, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "dialects" WHERE "dialect" = '정구지' AND "region" = '경상도');
+
+INSERT INTO "dialects" ("dialect", "standard", "meaning", "origin", "region", "example", "verified", "source", "latitude", "longitude", "created_at")
+SELECT '혼저옵서예', '어서 오세요', '손님을 반갑게 맞이하는 인사말', '제주 방언의 대표 인사말', '제주도', '혼저옵서예, 들어오세요', true, '제주 향토어 사전', 33.5, 126.5, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "dialects" WHERE "dialect" = '혼저옵서예' AND "region" = '제주도');
+
+INSERT INTO "dialects" ("dialect", "standard", "meaning", "origin", "region", "example", "verified", "source", "latitude", "longitude", "created_at")
+SELECT '자시고', '드시고', '식사 권유 표현', '충청도 사투리', '충청도', '밥 자시고 가세요', true, '충청도 방언집', 36.5, 127.5, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "dialects" WHERE "dialect" = '자시고' AND "region" = '충청도');


### PR DESCRIPTION
## 📌 관련 이슈
- close #4

## ✨ 작업 내용 요약
- 방언 사전 기능 전반 구현
  - 방언 추가 등록(`POST /api/dictionary`)
  - 전체 방언 목록 조회 (`GET /api/dictionary`)
  - 키워드 검색 기능 (`GET /api/dictionary/search?keyword=...`)
  - 지역별 필터 조회 (`GET /api/dictionary/region/{region}`)
  - 방언 상세보기 (`GET /api/dictionary/{id}`)
  - 지도용 마커 데이터 제공 (`GET /api/dictionary/map, /map/points`)
  - 북마크 추가/삭제 (`POST, DELETE /api/dictionary/{id}/bookmark`)
- 로그인 및 보안 처리
  - 구글 로그인 후 JWT 토큰 생성 및 프론트로 전달
  - Security 설정 :
    - 방언 조회는 로그인 없이도 가능
    - 북마크/검수 기능은 로그인 필요
    - 관리자는 검수(`PATCH`) 및 관리자 API 접근 가능
  - API 요청 시 권한 오류 → JSON으로 에러 응답 (401, 403)
- 기타 추가 기능
  - 방언 중복 등록 시 예외 처리 메시지 제공
  - 위도/경도 정보 자동 설정 (지역명 기반)
  - JWT 발급 URL: `http://localhost:3000/oauth2/redirect?token=...`

## 🗒️ 참고 사항
- 방언 사전 등록은 관리자 권한만 가능
- 실제 위도/경도는 지역명으로 자동 설정되며, 프론트에서 수정 가능
- 현재 설정은 개발용 (`ddl-auto: update`)이며, 배포 전 설정 변경 필요
- 지도 핀 클릭 → 방언 상세페이지 이동은 프론트 연동 후 테스트 예정
