### PR TITLE
Feat/6-tts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
 }
 
-group = 'com.satoori'
+group = 'com.moretale'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '21'
 targetCompatibility = '21'
@@ -24,6 +24,11 @@ dependencies {
     // Database
     runtimeOnly 'org.postgresql:postgresql'
 
+    // Google Cloud Services (Storage & TTS)
+    implementation 'com.google.cloud:google-cloud-storage:2.36.1'
+    implementation 'com.google.cloud:google-cloud-texttospeech:2.35.0'
+    implementation 'com.google.protobuf:protobuf-java:3.25.1'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
@@ -39,6 +44,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 // Java 컴파일 옵션

--- a/src/main/java/com/moretale/domain/story/controller/StoryController.java
+++ b/src/main/java/com/moretale/domain/story/controller/StoryController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
@@ -113,7 +114,7 @@ public class StoryController {
         return ApiResponse.success(null, "동화가 삭제되었습니다.");
     }
 
-    // Principal 객체에서 email 추출 (JWT / OAuth2 공통 처리)
+    // Principal에서 email 추출 (JWT UserPrincipal / OAuth2User / 테스트용 @WithMockUser)
     private String getEmailFromPrincipal(Object principal) {
         if (principal == null) {
             log.warn("Principal이 null입니다.");
@@ -134,6 +135,11 @@ public class StoryController {
                 throw new BusinessException(ErrorCode.USER_NOT_FOUND);
             }
             return email;
+        }
+
+        // 3. 테스트 코드 (@WithMockUser) 대응
+        if (principal instanceof User) {
+            return ((User) principal).getUsername();
         }
 
         log.error("지원하지 않는 Principal 타입: {}", principal.getClass().getName());

--- a/src/main/java/com/moretale/domain/story/entity/Slide.java
+++ b/src/main/java/com/moretale/domain/story/entity/Slide.java
@@ -24,7 +24,7 @@ public class Slide {
     @Column(name = "order_num", nullable = false)
     private Integer order;
 
-    @Column(name = "image_url", columnDefinition = "TEXT")
+    @Column(name = "image_url", length = 500)
     private String imageUrl;
 
     @Column(name = "text_kr", columnDefinition = "TEXT")
@@ -33,9 +33,9 @@ public class Slide {
     @Column(name = "text_native", columnDefinition = "TEXT")
     private String textNative;
 
-    @Column(name = "audio_url_kr", columnDefinition = "TEXT")
+    @Column(name = "audio_url_kr", length = 500)
     private String audioUrlKr;
 
-    @Column(name = "audio_url_native", columnDefinition = "TEXT")
+    @Column(name = "audio_url_native", length = 500)
     private String audioUrlNative;
 }

--- a/src/main/java/com/moretale/domain/story/repository/SlideRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/SlideRepository.java
@@ -2,6 +2,8 @@ package com.moretale.domain.story.repository;
 
 import com.moretale.domain.story.entity.Slide;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +14,18 @@ public interface SlideRepository extends JpaRepository<Slide, Long> {
     // 특정 동화의 슬라이드 목록 조회 (순서대로)
     List<Slide> findByStoryStoryIdOrderByOrderAsc(Long storyId);
 
-    // 특정 동화의 슬라이드 삭제
+    // 특정 동화의 슬라이드 목록 조회 (JPQL 명시 버전)
+    @Query("SELECT s FROM Slide s WHERE s.story.storyId = :storyId ORDER BY s.order ASC")
+    List<Slide> findByStoryIdOrderByOrder(@Param("storyId") Long storyId);
+
+    // TTS가 생성되지 않은 슬라이드 조회 (KR 또는 Native 중 하나라도 없는 경우)
+    @Query("""
+        SELECT s FROM Slide s
+        WHERE s.story.storyId = :storyId
+          AND (s.audioUrlKr IS NULL OR s.audioUrlNative IS NULL)
+    """)
+    List<Slide> findSlidesWithoutTTS(@Param("storyId") Long storyId);
+
+    // 특정 동화에 속한 모든 슬라이드 삭제
     void deleteByStoryStoryId(Long storyId);
 }

--- a/src/main/java/com/moretale/domain/tts/controller/TTSController.java
+++ b/src/main/java/com/moretale/domain/tts/controller/TTSController.java
@@ -1,0 +1,79 @@
+package com.moretale.domain.tts.controller;
+
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.dto.TTSResponse;
+import com.moretale.domain.tts.service.TTSGenerationService;
+import com.moretale.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/tts")
+@RequiredArgsConstructor
+public class TTSController {
+
+    private final TTSGenerationService ttsGenerationService;
+
+    // TTS 생성 API
+    @PostMapping("/generate")
+    public ResponseEntity<ApiResponse<TTSResponse>> generateTTS(
+            @Valid @RequestBody TTSRequest request
+    ) {
+        log.info("TTS 생성 요청 - 언어: {}, 텍스트 길이: {}",
+                request.getLanguage(), request.getText().length());
+
+        TTSResponse response = ttsGenerationService.generateSingleTTS(request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "TTS 생성 완료")
+        );
+    }
+
+    // 슬라이드 단위 TTS 재생성 (관리자/개발용)
+    @PostMapping("/regenerate/slide/{slideId}")
+    public ResponseEntity<ApiResponse<String>> regenerateSlideTS(
+            @PathVariable Long slideId,
+            @RequestParam String primaryLanguage,
+            @RequestParam String secondaryLanguage
+    ) {
+        log.info("슬라이드 {} TTS 재생성 요청", slideId);
+
+        ttsGenerationService.generateTTSForSlide(slideId, primaryLanguage, secondaryLanguage);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("슬라이드 TTS 재생성 완료")
+        );
+    }
+
+    // 동화 전체 TTS 재생성 (관리자/개발용)
+    @PostMapping("/regenerate/story/{storyId}")
+    public ResponseEntity<ApiResponse<String>> regenerateStoryTTS(
+            @PathVariable Long storyId
+    ) {
+        log.info("동화 {} 전체 TTS 재생성 요청", storyId);
+
+        ttsGenerationService.generateTTSForStory(storyId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("동화 전체 TTS 재생성 완료")
+        );
+    }
+
+    // 누락된 TTS만 재생성
+    @PostMapping("/regenerate/missing/{storyId}")
+    public ResponseEntity<ApiResponse<String>> regenerateMissingTTS(
+            @PathVariable Long storyId
+    ) {
+        log.info("동화 {} 누락된 TTS 재생성 요청", storyId);
+
+        ttsGenerationService.regenerateMissingTTS(storyId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("누락된 TTS 재생성 완료")
+        );
+    }
+}

--- a/src/main/java/com/moretale/domain/tts/dto/TTSRequest.java
+++ b/src/main/java/com/moretale/domain/tts/dto/TTSRequest.java
@@ -1,0 +1,23 @@
+package com.moretale.domain.tts.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TTSRequest {
+
+    @NotBlank(message = "텍스트는 필수입니다")
+    private String text;
+
+    @NotBlank(message = "언어 코드는 필수입니다")
+    // ko-KR, vi-VN, en-US 형식만 허용하도록 정규식 추가
+    @Pattern(regexp = "^(ko-KR|vi-VN|en-US)$", message = "지원하지 않는 언어 코드입니다. (ko-KR, vi-VN, en-US 중 하나여야 합니다.)")
+    private String language;
+
+    private String style;
+}

--- a/src/main/java/com/moretale/domain/tts/dto/TTSResponse.java
+++ b/src/main/java/com/moretale/domain/tts/dto/TTSResponse.java
@@ -1,0 +1,16 @@
+package com.moretale.domain.tts.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TTSResponse {
+
+    private String audioUrl;
+    private String language;
+    private Integer duration; // 음성 길이 (초)
+    private String message;
+}

--- a/src/main/java/com/moretale/domain/tts/service/AsyncTTSService.java
+++ b/src/main/java/com/moretale/domain/tts/service/AsyncTTSService.java
@@ -1,0 +1,26 @@
+package com.moretale.domain.tts.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncTTSService {
+
+    private final TTSGenerationService ttsGenerationService;
+
+    // 비동기로 동화 TTS 생성
+    @Async("ttsExecutor")
+    public void generateTTSAsync(Long storyId) {
+        try {
+            log.info("비동기 TTS 생성 시작 - 동화 ID: {}", storyId);
+            ttsGenerationService.generateTTSForStory(storyId);
+            log.info("비동기 TTS 생성 완료 - 동화 ID: {}", storyId);
+        } catch (Exception e) {
+            log.error("비동기 TTS 생성 실패 - 동화 ID: {}", storyId, e);
+        }
+    }
+}

--- a/src/main/java/com/moretale/domain/tts/service/TTSGenerationService.java
+++ b/src/main/java/com/moretale/domain/tts/service/TTSGenerationService.java
@@ -1,0 +1,123 @@
+package com.moretale.domain.tts.service;
+
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.SlideRepository;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.dto.TTSResponse;
+import com.moretale.global.exception.CustomException;
+import com.moretale.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TTSGenerationService {
+
+    private final TTSService ttsService;
+    private final StoryRepository storyRepository;
+    private final SlideRepository slideRepository;
+
+    // 단일 TTS 생성 (외부 API용)
+    public TTSResponse generateSingleTTS(TTSRequest request) {
+        return ttsService.generateTTS(request);
+    }
+
+    // 슬라이드에 대한 TTS 자동 생성
+    public void generateTTSForSlide(Long slideId, String primaryLanguage, String secondaryLanguage) {
+        Slide slide = slideRepository.findById(slideId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SLIDE_NOT_FOUND));
+
+        try {
+            // 한국어 TTS 생성
+            if (slide.getTextKr() != null && !slide.getTextKr().isEmpty()) {
+                String audioUrlKr = ttsService.generateAudioUrl(
+                        slide.getTextKr(),
+                        primaryLanguage
+                );
+                slide.setAudioUrlKr(audioUrlKr);
+            }
+
+            // 부모 언어 TTS 생성
+            if (slide.getTextNative() != null && !slide.getTextNative().isEmpty()) {
+                String audioUrlNative = ttsService.generateAudioUrl(
+                        slide.getTextNative(),
+                        secondaryLanguage
+                );
+                slide.setAudioUrlNative(audioUrlNative);
+            }
+
+            slideRepository.save(slide);
+            log.info("슬라이드 {} TTS 생성 완료", slideId);
+
+        } catch (Exception e) {
+            log.error("슬라이드 {} TTS 생성 실패", slideId, e);
+            throw new CustomException(ErrorCode.TTS_GENERATION_FAILED);
+        }
+    }
+
+    // 동화 전체 슬라이드에 대한 TTS 생성
+    public void generateTTSForStory(Long storyId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        List<Slide> slides = slideRepository.findByStoryIdOrderByOrder(storyId);
+
+        String primaryLanguage = convertToLanguageCode(story.getPrimaryLanguage());
+        String secondaryLanguage = convertToLanguageCode(story.getSecondaryLanguage());
+
+        for (Slide slide : slides) {
+            try {
+                generateTTSForSlide(slide.getSlideId(), primaryLanguage, secondaryLanguage);
+            } catch (Exception e) {
+                log.error("슬라이드 {} TTS 생성 중 오류 발생", slide.getSlideId(), e);
+                // 하나 실패해도 계속 진행
+            }
+        }
+
+        log.info("동화 {} 전체 TTS 생성 완료", storyId);
+    }
+
+    // TTS가 없는 슬라이드만 재생성
+    public void regenerateMissingTTS(Long storyId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        List<Slide> slidesWithoutTTS = slideRepository.findSlidesWithoutTTS(storyId);
+
+        if (slidesWithoutTTS.isEmpty()) {
+            log.info("동화 {} - 재생성할 TTS 없음", storyId);
+            return;
+        }
+
+        String primaryLanguage = convertToLanguageCode(story.getPrimaryLanguage());
+        String secondaryLanguage = convertToLanguageCode(story.getSecondaryLanguage());
+
+        for (Slide slide : slidesWithoutTTS) {
+            generateTTSForSlide(slide.getSlideId(), primaryLanguage, secondaryLanguage);
+        }
+
+        log.info("동화 {} - 누락된 TTS {} 개 재생성 완료", storyId, slidesWithoutTTS.size());
+    }
+
+    // 언어 코드 변환 (ko -> ko-KR, vi -> vi-VN 등)
+    private String convertToLanguageCode(String languageShort) {
+        return switch (languageShort.toLowerCase()) {
+            case "ko" -> "ko-KR";
+            case "vi" -> "vi-VN";
+            case "en" -> "en-US";
+            case "zh" -> "zh-CN";
+            case "ja" -> "ja-JP";
+            case "tl" -> "fil-PH"; // 필리핀어
+            case "mn" -> "mn-MN"; // 몽골어
+            default -> "ko-KR"; // 기본값
+        };
+    }
+}

--- a/src/main/java/com/moretale/domain/tts/service/TTSService.java
+++ b/src/main/java/com/moretale/domain/tts/service/TTSService.java
@@ -1,0 +1,25 @@
+package com.moretale.domain.tts.service;
+
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.dto.TTSResponse;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+
+import java.util.Set;
+
+public interface TTSService {
+
+    // TTS 생성
+    TTSResponse generateTTS(TTSRequest request);
+
+    // 텍스트 + 언어 코드로 오디오 URL 생성 (내부 사용)
+    String generateAudioUrl(String text, String language);
+
+    // 언어 코드 유효성 검증 (ko-KR, vi-VN, en-US)
+    default void validateLanguage(String language) {
+        Set<String> supportedLanguages = Set.of("ko-KR", "vi-VN", "en-US");
+        if (!supportedLanguages.contains(language)) {
+            throw new BusinessException(ErrorCode.TTS_INVALID_LANGUAGE);
+        }
+    }
+}

--- a/src/main/java/com/moretale/domain/tts/service/impl/GoogleTTSServiceImpl.java
+++ b/src/main/java/com/moretale/domain/tts/service/impl/GoogleTTSServiceImpl.java
@@ -1,0 +1,126 @@
+package com.moretale.domain.tts.service.impl;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.texttospeech.v1.*;
+import com.google.protobuf.ByteString;
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.dto.TTSResponse;
+import com.moretale.domain.tts.service.TTSService;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import com.moretale.global.service.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleTTSServiceImpl implements TTSService {
+
+    @Value("${google.cloud.credentials.location}")
+    private String credentialsLocation;
+
+    @Value("${tts.storage.path}")
+    private String storagePath;
+
+    private final FileStorageService fileStorageService;
+    private final ResourceLoader resourceLoader;
+
+    @Override
+    public TTSResponse generateTTS(TTSRequest request) {
+        // 언어 검증 추가
+        validateLanguage(request.getLanguage());
+
+        log.info("TTS 생성 요청 시작 - 언어: {}, 텍스트 길이: {}",
+                request.getLanguage(), request.getText().length());
+
+        try {
+            Resource resource = resourceLoader.getResource(credentialsLocation);
+            GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+
+            TextToSpeechSettings settings = TextToSpeechSettings.newBuilder()
+                    .setCredentialsProvider(() -> credentials)
+                    .build();
+
+            try (TextToSpeechClient textToSpeechClient = TextToSpeechClient.create(settings)) {
+                SynthesisInput input = SynthesisInput.newBuilder()
+                        .setText(request.getText())
+                        .build();
+
+                VoiceSelectionParams voice = VoiceSelectionParams.newBuilder()
+                        .setLanguageCode(request.getLanguage())
+                        .setSsmlGender(SsmlVoiceGender.NEUTRAL)
+                        .build();
+
+                AudioConfig audioConfig = AudioConfig.newBuilder()
+                        .setAudioEncoding(AudioEncoding.MP3)
+                        .setSpeakingRate(1.0)
+                        .setPitch(0.0)
+                        .build();
+
+                SynthesizeSpeechResponse response = textToSpeechClient.synthesizeSpeech(input, voice, audioConfig);
+                ByteString audioContents = response.getAudioContent();
+
+                String fileName = generateFileName(request.getLanguage());
+                String audioUrl = saveAudioFile(audioContents.toByteArray(), fileName);
+
+                log.info("TTS 생성 및 업로드 완료 - URL: {}", audioUrl);
+
+                return TTSResponse.builder()
+                        .audioUrl(audioUrl)
+                        .language(request.getLanguage())
+                        .message("TTS 생성 성공")
+                        .build();
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Google TTS API 호출 중 상세 에러 발생: ", e);
+            throw new BusinessException(ErrorCode.TTS_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public String generateAudioUrl(String text, String language) {
+        TTSRequest request = TTSRequest.builder()
+                .text(text)
+                .language(language)
+                .build();
+
+        TTSResponse response = generateTTS(request);
+        return response.getAudioUrl();
+    }
+
+    private String generateFileName(String language) {
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        return String.format("tts_%s_%s_%s.mp3", language, timestamp, uuid);
+    }
+
+    private String saveAudioFile(byte[] audioData, String fileName) throws IOException {
+        Path tempDir = Files.createTempDirectory("tts_temp");
+        Path tempFile = tempDir.resolve(fileName);
+
+        try (FileOutputStream fos = new FileOutputStream(tempFile.toFile())) {
+            fos.write(audioData);
+        }
+
+        String subPath = storagePath + "/" + fileName;
+        String audioUrl = fileStorageService.uploadFile(tempFile.toFile(), subPath);
+
+        Files.deleteIfExists(tempFile);
+        Files.deleteIfExists(tempDir);
+
+        return audioUrl;
+    }
+}

--- a/src/main/java/com/moretale/domain/tts/service/impl/MockTTSServiceImpl.java
+++ b/src/main/java/com/moretale/domain/tts/service/impl/MockTTSServiceImpl.java
@@ -1,0 +1,89 @@
+package com.moretale.domain.tts.service.impl;
+
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.dto.TTSResponse;
+import com.moretale.domain.tts.service.TTSService;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import com.moretale.global.service.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+// Mock TTS 서비스 (개발/테스트용, Google Cloud TTS 없이 더미 오디오 생성)
+@Slf4j
+@Service
+@Primary
+@Profile({"dev", "local"})
+@RequiredArgsConstructor
+public class MockTTSServiceImpl implements TTSService {
+
+    private final FileStorageService fileStorageService;
+
+    @Value("${tts.storage.path:tts/audio}")
+    private String storagePath;
+
+    @Override
+    public TTSResponse generateTTS(TTSRequest request) {
+        // 언어 검증 추가
+        validateLanguage(request.getLanguage());
+
+        try {
+            log.info("[Mock TTS] 생성 시작 - 언어: {}, 텍스트: {}",
+                    request.getLanguage(),
+                    request.getText().substring(0, Math.min(50, request.getText().length())));
+
+            // 더미 오디오 데이터 생성
+            byte[] dummyAudioData = generateDummyAudioData();
+
+            // 파일명 생성
+            String fileName = generateFileName(request.getLanguage());
+            String filePath = storagePath + "/" + fileName;
+
+            // 파일 저장
+            String audioUrl = fileStorageService.uploadFile(dummyAudioData, filePath);
+
+            log.info("[Mock TTS] 생성 완료 - URL: {}", audioUrl);
+
+            return TTSResponse.builder()
+                    .audioUrl(audioUrl)
+                    .language(request.getLanguage())
+                    .duration(5)
+                    .message("Mock TTS 생성 완료")
+                    .build();
+
+        } catch (BusinessException e) {
+            throw e; // 검증 에러는 그대로 던짐
+        } catch (Exception e) {
+            log.error("[Mock TTS] 생성 실패", e);
+            throw new BusinessException(ErrorCode.TTS_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public String generateAudioUrl(String text, String language) {
+        TTSRequest request = TTSRequest.builder()
+                .text(text)
+                .language(language)
+                .build();
+
+        TTSResponse response = generateTTS(request);
+        return response.getAudioUrl();
+    }
+
+    private byte[] generateDummyAudioData() {
+        String dummyContent = "MOCK_TTS_AUDIO_DATA_" + UUID.randomUUID();
+        return dummyContent.getBytes();
+    }
+
+    private String generateFileName(String language) {
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        return String.format("tts_%s_%s_%s.mp3", language, timestamp, uuid);
+    }
+}

--- a/src/main/java/com/moretale/global/config/AsyncConfig.java
+++ b/src/main/java/com/moretale/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.moretale.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync // @Async 비동기 메서드 활성화
+public class AsyncConfig {
+
+    @Bean(name = "ttsExecutor")
+    public Executor ttsExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("TTS-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/moretale/global/config/WebConfig.java
+++ b/src/main/java/com/moretale/global/config/WebConfig.java
@@ -1,0 +1,38 @@
+package com.moretale.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.base-path:uploads}")
+    private String uploadPath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 절대 경로로 변환
+        Path absolutePath = Paths.get(uploadPath).toAbsolutePath();
+
+        // Windows 경로를 URL 형식으로 변환 (역슬래시 -> 슬래시)
+        String normalizedPath = absolutePath.toString().replace("\\", "/");
+
+        // file:/// 프로토콜 추가
+        String fileLocation = "file:///" + normalizedPath + "/";
+
+        // 업로드된 파일을 HTTP로 접근 가능하도록 설정
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(fileLocation);
+
+        System.out.println("======================================");
+        System.out.println("Static Resource Mapping Configured:");
+        System.out.println("  URL Pattern: /uploads/**");
+        System.out.println("  File Location: " + fileLocation);
+        System.out.println("======================================");
+    }
+}

--- a/src/main/java/com/moretale/global/controller/FileTestController.java
+++ b/src/main/java/com/moretale/global/controller/FileTestController.java
@@ -1,0 +1,54 @@
+package com.moretale.global.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+
+@RestController
+public class FileTestController {
+
+    @Value("${file.upload.base-path:uploads}")
+    private String basePath;
+
+    @Value("${file.upload.base-url:http://localhost:8080/uploads}")
+    private String baseUrl;
+
+    @GetMapping("/api/test/file-path")
+    public Map<String, Object> testFilePath() {
+        Map<String, Object> result = new HashMap<>();
+
+        Path absolutePath = Paths.get(basePath).toAbsolutePath();
+        result.put("configuredPath", basePath);
+        result.put("absolutePath", absolutePath.toString());
+        result.put("exists", Files.exists(absolutePath));
+        result.put("isDirectory", Files.isDirectory(absolutePath));
+        result.put("baseUrl", baseUrl);
+
+        File audioDir = new File(absolutePath.toFile(), "tts/audio");
+        result.put("audioDirPath", audioDir.getAbsolutePath());
+        result.put("audioDirExists", audioDir.exists());
+
+        if (audioDir.exists()) {
+            File[] files = audioDir.listFiles();
+            if (files != null && files.length > 0) {
+                result.put("fileCount", files.length);
+                result.put("files", Arrays.stream(files)
+                        .map(File::getName)
+                        .collect(Collectors.toList()));
+            } else {
+                result.put("fileCount", 0);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/moretale/global/exception/ErrorCode.java
+++ b/src/main/java/com/moretale/global/exception/ErrorCode.java
@@ -8,39 +8,46 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // User 관련
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
-
-    // Profile 관련
-    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로필을 찾을 수 없습니다."),
-    PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "P002", "이미 프로필이 존재합니다."),
-
-    // Story 관련
-    STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "동화를 찾을 수 없습니다."),
-    STORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S002", "동화에 접근할 권한이 없습니다."),
-    STORY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S003", "동화 생성에 실패했습니다."),
-    STORY_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S004", "동화 저장에 실패했습니다."),
-
-    // Slide 관련
-    SLIDE_NOT_FOUND(HttpStatus.NOT_FOUND, "SL001", "슬라이드를 찾을 수 없습니다."),
-    INVALID_SLIDE_ORDER(HttpStatus.BAD_REQUEST, "SL002", "슬라이드 순서가 올바르지 않습니다."),
-
-    // TTS 관련
-    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "T001", "음성 생성에 실패했습니다."),
-    INVALID_LANGUAGE_CODE(HttpStatus.BAD_REQUEST, "T002", "지원하지 않는 언어 코드입니다."),
-
-    // AI 관련
-    AI_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A001", "AI 서비스 오류가 발생했습니다."),
-    AI_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "A002", "AI 응답이 올바르지 않습니다."),
-
-    // 공통
+    // 공통 (Common)
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C002", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "C003", "권한이 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 오류가 발생했습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "허용되지 않은 메서드입니다."),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C006", "요청한 리소스를 찾을 수 없습니다.");
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C006", "요청한 리소스를 찾을 수 없습니다."),
+
+    // 사용자 (User)
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
+
+    // 프로필 (Profile)
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로필을 찾을 수 없습니다."),
+    PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "P002", "이미 프로필이 존재합니다."),
+
+    // 동화 (Story)
+    STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "동화를 찾을 수 없습니다."),
+    STORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S002", "동화에 접근할 권한이 없습니다."),
+    STORY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S003", "동화 생성에 실패했습니다."),
+    STORY_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S004", "동화 저장에 실패했습니다."),
+
+    // 슬라이드 (Slide)
+    SLIDE_NOT_FOUND(HttpStatus.NOT_FOUND, "SL001", "슬라이드를 찾을 수 없습니다."),
+    INVALID_SLIDE_ORDER(HttpStatus.BAD_REQUEST, "SL002", "슬라이드 순서가 올바르지 않습니다."),
+
+    // 음성 생성 (TTS)
+    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "T001", "음성 생성(TTS)에 실패했습니다."),
+    TTS_INVALID_LANGUAGE(HttpStatus.BAD_REQUEST, "T002", "지원하지 않는 언어 코드입니다."),
+    TTS_TEXT_TOO_LONG(HttpStatus.BAD_REQUEST, "T003", "텍스트가 너무 깁니다 (최대 5000자)"),
+
+    // AI 서비스 (AI)
+    AI_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A001", "AI 서비스 오류가 발생했습니다."),
+    AI_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "A002", "AI 응답이 올바르지 않습니다."),
+
+    // 파일/저장 (File)
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "파일을 찾을 수 없습니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F003", "파일 크기가 제한을 초과했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 삭제에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/moretale/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moretale/global/exception/GlobalExceptionHandler.java
@@ -15,10 +15,22 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // 비즈니스 로직 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
+    }
+
     // Custom Exception 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
-        log.error("CustomException: {}", e.getMessage(), e);
+        log.error("CustomException: {}", e.getMessage());
 
         ErrorCode errorCode = e.getErrorCode();
 
@@ -49,7 +61,8 @@ public class GlobalExceptionHandler {
     // 기타 Exception 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("Exception: {}", e.getMessage(), e);
+        // 상세 스택 트레이스는 로그로 남겨 추적 가능하게 함
+        log.error("Unexpected Exception: ", e);
 
         return ResponseEntity
                 .internalServerError()

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -45,8 +45,14 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/dictionary/**").permitAll()                 // 방언 사전 조회는 비회원 가능
                         .requestMatchers("/error").permitAll()                                             // Spring Boot 에러 페이지
 
+                        // TTS API 테스트용 (개발 환경에서만 permitAll, 운영에서는 authenticated로 변경)
+                        .requestMatchers("/api/tts/**").permitAll()                                        // TTS API 테스트
+
+                        // 업로드된 파일 접근 허용 (TTS 오디오 파일 다운로드용)
+                        .requestMatchers("/uploads/**").permitAll()
+
                         // 동화 생성 API (인증 필요)
-                        .requestMatchers("/api/stories/**").authenticated()                                // ✅ 추가
+                        .requestMatchers("/api/stories/**").authenticated()
 
                         // 로그인 필요
                         .requestMatchers(HttpMethod.POST, "/api/dictionary/*/bookmark").authenticated()    // 북마크 추가

--- a/src/main/java/com/moretale/global/service/FileStorageService.java
+++ b/src/main/java/com/moretale/global/service/FileStorageService.java
@@ -1,0 +1,129 @@
+package com.moretale.global.service;
+
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class FileStorageService {
+
+    @Value("${file.upload.base-path:uploads}")
+    private String basePath;
+
+    @Value("${file.upload.base-url:http://localhost:8080/uploads}")
+    private String baseUrl;
+
+    // 파일 업로드 (File 객체)
+    public String uploadFile(File file, String subPath) {
+        try {
+            Path targetPath = createDirectoriesAndGetPath(subPath);
+            Files.copy(file.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            String fileUrl = generateUrl(subPath);
+            log.info("파일 업로드 완료 - 실제 경로: {}, 접근 URL: {}",
+                    targetPath.toAbsolutePath(), fileUrl);
+
+            return fileUrl;
+        } catch (IOException e) {
+            log.error("File upload failed: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    // 파일 업로드 (MultipartFile)
+    public String uploadFile(MultipartFile file, String subPath) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        try {
+            Path targetPath = createDirectoriesAndGetPath(subPath);
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            String fileUrl = generateUrl(subPath);
+            log.info("파일 업로드 완료 - 실제 경로: {}, 접근 URL: {}",
+                    targetPath.toAbsolutePath(), fileUrl);
+
+            return fileUrl;
+        } catch (IOException e) {
+            log.error("MultipartFile upload failed: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    // 바이트 배열로 파일 저장 (TTS 음성 데이터 저장 시 주로 사용)
+    public String uploadFile(byte[] data, String subPath) {
+        try {
+            Path targetPath = createDirectoriesAndGetPath(subPath);
+            Files.write(targetPath, data);
+
+            String fileUrl = generateUrl(subPath);
+            log.info("파일 저장 완료 - 실제 경로: {}, 접근 URL: {}",
+                    targetPath.toAbsolutePath(), fileUrl);
+
+            return fileUrl;
+        } catch (IOException e) {
+            log.error("Byte array upload failed: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    // 파일 삭제
+    public void deleteFile(String subPath) {
+        try {
+            Path filePath = Paths.get(basePath, subPath);
+            if (Files.deleteIfExists(filePath)) {
+                log.info("파일 삭제 완료: {}", subPath);
+            }
+        } catch (IOException e) {
+            log.error("파일 삭제 실패: {}", subPath, e);
+            // 삭제 실패는 핵심 로직을 멈추지 않도록 로그만 남깁니다.
+        }
+    }
+
+    // 랜덤 파일명 생성
+    public String generateRandomFileName(String originalFileName, String prefix) {
+        String extension = "";
+        if (originalFileName != null && originalFileName.contains(".")) {
+            extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        }
+
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        String timestamp = String.valueOf(System.currentTimeMillis());
+
+        return String.format("%s_%s_%s%s", prefix, timestamp, uuid, extension);
+    }
+
+    // 디렉토리 생성 및 전체 경로 반환
+    private Path createDirectoriesAndGetPath(String subPath) throws IOException {
+        // 절대 경로로 변환
+        Path absoluteBasePath = Paths.get(basePath).toAbsolutePath();
+        Path targetPath = absoluteBasePath.resolve(subPath);
+
+        // 부모 디렉토리 생성
+        Path parentDir = targetPath.getParent();
+        if (parentDir != null && !Files.exists(parentDir)) {
+            Files.createDirectories(parentDir);
+            log.info("디렉토리 생성: {}", parentDir);
+        }
+
+        return targetPath;
+    }
+
+    // 파일 접근 URL 생성
+    private String generateUrl(String subPath) {
+        return baseUrl + "/" + subPath;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,17 @@ server:
   port: 8080
 
 spring:
+  profiles:
+    active: dev  # dev 프로필 활성화 (MockTTSServiceImpl 사용)
+
+  # 데이터베이스 설정
   datasource:
     url: jdbc:postgresql://localhost:5432/moretale
     username: postgres
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  # JPA 설정
   jpa:
     hibernate:
       ddl-auto: update
@@ -18,11 +23,13 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  # SQL 초기화 설정
   sql:
     init:
       mode: always
       encoding: UTF-8
 
+  # OAuth2 보안 설정
   security:
     oauth2:
       client:
@@ -41,11 +48,31 @@ spring:
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
 
+  # 비동기 처리 설정
+  task:
+    execution:
+      pool:
+        core-size: 2
+        max-size: 5
+        queue-capacity: 100
+
+# JWT 설정
 jwt:
   secret: ${JWT_SECRET}
   expiration: 86400000
 
-# MoreTale AI 동화 생성 외부 서버 URL 설정
+# 파일 업로드 설정
+file:
+  upload:
+    base-path: ${user.home}/moretale/uploads
+    base-url: http://localhost:8080/uploads
+
+# TTS 저장 경로
+tts:
+  storage:
+    path: tts/audio
+
+# MoreTale AI 서비스 연동 설정
 moretale:
   ai:
     story-generation-url: ${STORY_GENERATION_URL:http://localhost:8081}
@@ -54,3 +81,12 @@ moretale:
     url: ${TTS_URL:http://localhost:8083}
   quiz:
     auto-generation-url: ${QUIZ_GENERATION_URL:http://localhost:8084}
+
+# Google Cloud 설정 (운영 환경용)
+google:
+  cloud:
+    storage:
+      bucket: moretale-audio-bucket
+      base-url: https://storage.googleapis.com
+    credentials:
+      location: classpath:gcp-service-account.json

--- a/src/test/java/com/moretale/ProfileIntegrationTest.java
+++ b/src/test/java/com/moretale/ProfileIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.moretale;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moretale.domain.profile.dto.UserProfileRequest;
+import com.moretale.domain.user.entity.User.Role;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ProfileIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        // DB에 테스트 유저 생성 (Service에서 userId로 조회할 수 있어야 함)
+        testUser = User.builder()
+                .email("test@example.com")
+                .nickname("테스트유저")
+                .role(Role.USER)
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Test
+    @DisplayName("새로운 아이 프로필 생성 성공 테스트")
+    void createProfileSuccess() throws Exception {
+        // given
+        UserProfileRequest request = UserProfileRequest.builder()
+                .childName("유찬")
+                .childAge(5)
+                .childNationality("대한민국")
+                .parentCountry("베트남")
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .build();
+
+        // UserPrincipal 객체를 직접 생성하여 MockUser로 주입 (컨트롤러의 UserPrincipal 대응)
+        UserPrincipal principal = UserPrincipal.create(testUser);
+
+        // when & then
+        mockMvc.perform(post("/api/users/profile")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.childName").value("유찬"));
+    }
+
+    @Test
+    @DisplayName("필수 정보(부모 국가) 누락 시 프로필 생성 실패 테스트")
+    @WithMockUser // Validation 에러는 Principal 이전에 발생하므로 기본 MockUser도 무방
+    void createProfileValidationFail() throws Exception {
+        // given: @NotBlank인 parentCountry 누락
+        UserProfileRequest request = UserProfileRequest.builder()
+                .childName("유찬")
+                .childAge(5)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/users/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자의 프로필 접근 차단 테스트")
+    void profileAccessDeniedWithoutLogin() throws Exception {
+        mockMvc.perform(get("/api/users/profile/list"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/moretale/StoryCreationFlowIntegrationTest.java
+++ b/src/test/java/com/moretale/StoryCreationFlowIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.moretale;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moretale.domain.profile.dto.UserProfileRequest;
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.StorySaveRequest;
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.entity.User.Role;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class StoryCreationFlowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    private User testUser;
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("flow-test@example.com")
+                .nickname("시나리오유저")
+                .role(Role.USER)
+                .build();
+        userRepository.save(testUser);
+        principal = UserPrincipal.create(testUser);
+    }
+
+    @Test
+    @DisplayName("전체 시나리오 테스트: 프로필 생성 -> TTS 준비 -> 동화 저장 -> 목록 조회")
+    void fullStoryCreationFlowTest() throws Exception {
+
+        // 1. 아이 프로필 생성
+        UserProfileRequest profileReq = UserProfileRequest.builder()
+                .childName("유찬")
+                .childAge(5)
+                .childNationality("South Korea")
+                .parentCountry("Vietnam")
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .build();
+
+        MvcResult profileResult = mockMvc.perform(post("/api/users/profile")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(profileReq)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long profileId = objectMapper.readTree(profileResult.getResponse().getContentAsString())
+                .path("data").path("profileId").asLong();
+
+        // 2. TTS 음성 미리 생성 (동화 슬라이드에 넣을 용도)
+        TTSRequest ttsReq = TTSRequest.builder()
+                .text("옛날 옛적에 사자가 살았어요.")
+                .language("ko-KR")
+                .build();
+
+        MvcResult ttsResult = mockMvc.perform(post("/api/tts/generate")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(ttsReq)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String generatedAudioUrl = objectMapper.readTree(ttsResult.getResponse().getContentAsString())
+                .path("data").path("audioUrl").asText();
+
+        // 3. 생성된 프로필과 TTS URL을 사용하여 동화 저장
+        StorySaveRequest.SlideRequest slide = StorySaveRequest.SlideRequest.builder()
+                .order(1)
+                .textKr("옛날 옛적에 사자가 살았어요.")
+                .textNative("Ngày xửa ngày xưa, có một con sư tử.")
+                .audioUrlKr(generatedAudioUrl) // 위에서 생성된 URL 사용
+                .audioUrlNative("http://example.com/native-audio.mp3")
+                .imageUrl("http://example.com/lion.png")
+                .build();
+
+        StorySaveRequest storyReq = StorySaveRequest.builder()
+                .title("용감한 사자 유찬이")
+                .prompt("사자와 아이의 우정")
+                .profileId(profileId) // 위에서 생성된 프로필 ID 사용
+                .slides(List.of(slide))
+                .build();
+
+        mockMvc.perform(post("/api/stories")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(storyReq)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("용감한 사자 유찬이"));
+
+        // 4. 사용자의 전체 동화 목록 조회하여 저장 확인
+        mockMvc.perform(get("/api/stories/my")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                // 목록 중 첫 번째 항목의 제목이 저장한 것과 일치하는지 확인
+                .andExpect(jsonPath("$.data[0].title").value("용감한 사자 유찬이"));
+    }
+
+    @Test
+    @DisplayName("예외 시나리오: 다른 사용자의 프로필 ID로 동화 저장을 시도할 경우 403 에러 발생")
+    void createStoryWithOtherUserProfileFail() throws Exception {
+        // 1. 새로운 '남의 유저'와 '남의 프로필' 생성
+        User otherUser = User.builder()
+                .email("other@example.com")
+                .nickname("남의이름")
+                .role(Role.USER)
+                .build();
+        userRepository.save(otherUser);
+
+        UserProfile otherProfile = UserProfile.builder()
+                .childName("남의아이")
+                .childAge(7)
+                .childNationality("KR")
+                .parentCountry("VN")
+                .user(otherUser)
+                .primaryLanguage("ko")
+                .secondaryLanguage("en")
+                .build();
+        userProfileRepository.save(otherProfile);
+
+        // 2. 현재 로그인한 사용자(testUser)가 남의 프로필 ID로 저장 요청
+        StorySaveRequest.SlideRequest slide = StorySaveRequest.SlideRequest.builder()
+                .order(1)
+                .textKr("훔치기 테스트")
+                .build();
+
+        StorySaveRequest request = StorySaveRequest.builder()
+                .title("가로채기 시도")
+                .prompt("남의 프로필로 저장")
+                .profileId(otherProfile.getProfileId()) // 남의 프로필 ID 입력
+                .slides(List.of(slide))
+                .build();
+
+        // 3. 요청 실행 및 결과 검증 (403 Forbidden 기대)
+        mockMvc.perform(post("/api/stories")
+                        .with(SecurityMockMvcRequestPostProcessors.user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("S002"))
+                .andExpect(jsonPath("$.success").value(false));
+    }
+}

--- a/src/test/java/com/moretale/StoryServiceDetailTest.java
+++ b/src/test/java/com/moretale/StoryServiceDetailTest.java
@@ -6,6 +6,7 @@ import com.moretale.domain.story.dto.StoryResponse;
 import com.moretale.domain.story.dto.StorySaveRequest;
 import com.moretale.domain.story.dto.StoryShareRequest;
 import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.SlideRepository;
 import com.moretale.domain.story.repository.StoryRepository;
 import com.moretale.domain.story.service.StoryService;
 import com.moretale.domain.user.entity.User;
@@ -39,6 +40,8 @@ public class StoryServiceDetailTest {
     @Mock
     private StoryRepository storyRepository;
     @Mock
+    private SlideRepository slideRepository;
+    @Mock
     private UserRepository userRepository;
     @Mock
     private UserProfileRepository userProfileRepository;
@@ -52,7 +55,13 @@ public class StoryServiceDetailTest {
     void setUp() {
         user = User.builder().userId(1L).email("test@example.com").build();
         otherUser = User.builder().userId(2L).email("other@example.com").build();
-        profile = UserProfile.builder().profileId(3L).childName("민지").user(user).build();
+
+        // 유찬 대신 민지 프로필 (ID: 3, 소유자: user)
+        profile = UserProfile.builder()
+                .profileId(3L)
+                .childName("민지")
+                .user(user)
+                .build();
 
         story = Story.builder()
                 .storyId(100L)
@@ -77,7 +86,11 @@ public class StoryServiceDetailTest {
                 .build();
 
         given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
-        given(userProfileRepository.findByProfileIdAndUser_UserId(anyLong(), anyLong())).willReturn(Optional.of(profile));
+
+        // findByProfileIdAndUser_UserId 대신 findById 사용
+        given(userProfileRepository.findById(3L)).willReturn(Optional.of(profile));
+
+        // save 호출 시 인자로 받은 객체 그대로 반환하도록 설정
         given(storyRepository.save(any(Story.class))).willReturn(story);
 
         // when

--- a/src/test/java/com/moretale/StoryTtsIntegrationTest.java
+++ b/src/test/java/com/moretale/StoryTtsIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.moretale;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.StorySaveRequest;
+import com.moretale.domain.user.entity.User.Role;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class StoryTtsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    private User testUser;
+    private UserProfile testProfile;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .nickname("테스트유저")
+                .role(Role.USER)
+                .build();
+        userRepository.save(testUser);
+
+        testProfile = UserProfile.builder()
+                .childName("민준")
+                .childAge(5)
+                .parentCountry("Vietnam")
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .user(testUser)
+                .build();
+        userProfileRepository.save(testProfile);
+    }
+
+    @Test
+    @DisplayName("동화 저장 시 TTS URL이 슬라이드에 정상적으로 포함되어 저장되는지 테스트")
+    @WithMockUser(username = "test@example.com")
+    void createStoryWithTtsUrlsSuccess() throws Exception {
+        // given
+        StorySaveRequest.SlideRequest slide1 = StorySaveRequest.SlideRequest.builder()
+                .order(1)
+                .textKr("민준이는 사자를 봤어요.")
+                .textNative("Minjun đã nhìn thấy con sư tử.")
+                .audioUrlKr("http://localhost:8080/uploads/tts/audio/ko_sample.mp3")
+                .audioUrlNative("http://localhost:8080/uploads/tts/audio/vi_sample.mp3")
+                .imageUrl("http://example.com/image1.png")
+                .build();
+
+        StorySaveRequest request = StorySaveRequest.builder()
+                .title("사자 이야기")
+                .prompt("사자와 민준이의 만남")
+                .profileId(testProfile.getProfileId())
+                .slides(List.of(slide1))
+                .build();
+
+        // when & then: status().isCreated() 로 수정 (201 응답 대응)
+        MvcResult result = mockMvc.perform(post("/api/stories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated()) // 핵심 수정 사항: isOk() -> isCreated()
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        long storyId = objectMapper.readTree(responseBody).path("data").path("storyId").asLong();
+
+        // 상세 조회는 컨트롤러에서 @ResponseStatus가 없으므로 200 OK
+        mockMvc.perform(get("/api/stories/" + storyId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.slides[0].audioUrlKr").value("http://localhost:8080/uploads/tts/audio/ko_sample.mp3"))
+                .andExpect(jsonPath("$.data.slides[0].audioUrlNative").value("http://localhost:8080/uploads/tts/audio/vi_sample.mp3"));
+    }
+
+    @Test
+    @DisplayName("필수 값(제목) 누락 시 Validation 에러 발생 테스트")
+    @WithMockUser(username = "test@example.com")
+    void createStoryValidationFail() throws Exception {
+        StorySaveRequest request = StorySaveRequest.builder()
+                .title("")
+                .slides(List.of())
+                .build();
+
+        mockMvc.perform(post("/api/stories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+}

--- a/src/test/java/com/moretale/TtsIntegrationTest.java
+++ b/src/test/java/com/moretale/TtsIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.moretale;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moretale.domain.tts.dto.TTSRequest;
+import com.moretale.domain.tts.service.TTSService;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class TtsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TTSService ttsService;
+
+    @Test
+    @DisplayName("1. 한국어 TTS 생성 요청 성공 테스트")
+    @WithMockUser // Security permitAll 설정 확인용
+    void generateKoreanTtsSuccess() throws Exception {
+        // given
+        TTSRequest request = TTSRequest.builder()
+                .text("안녕하세요, 테스트 음성입니다.")
+                .language("ko-KR")
+                .style("child_friendly")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/tts/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.audioUrl").isNotEmpty())
+                .andExpect(jsonPath("$.data.language").value("ko-KR"));
+    }
+
+    @Test
+    @DisplayName("2. 다국어(베트남어) TTS 생성 요청 성공 테스트")
+    void generateVietnameseTtsSuccess() throws Exception {
+        // given
+        TTSRequest request = TTSRequest.builder()
+                .text("Xin chào, đây là giọng nói thử nghiệm.")
+                .language("vi-VN")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/tts/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.language").value("vi-VN"));
+    }
+
+    @Test
+    @DisplayName("3. 유효하지 않은 언어 코드 요청 시 에러 발생")
+    void generateTtsInvalidLanguageFail() throws Exception {
+        // given
+        TTSRequest request = TTSRequest.builder()
+                .text("Test")
+                .language("invalid-code")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/tts/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        // ErrorCode 적용 방식에 따라 jsonPath("$.code").value("T002") 추가 가능
+    }
+
+    @Test
+    @DisplayName("4. 생성된 파일의 URL로 실제 파일 접근 가능 여부 테스트")
+    void verifyGeneratedFileAccess() throws Exception {
+        // 1. 먼저 TTS 생성
+        TTSRequest request = TTSRequest.builder()
+                .text("파일 접근 테스트")
+                .language("ko-KR")
+                .build();
+
+        String responseString = mockMvc.perform(post("/api/tts/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn().getResponse().getContentAsString();
+
+        // 2. 응답에서 URL 추출 (예: http://localhost:8080/uploads/...)
+        String audioUrl = objectMapper.readTree(responseString).path("data").path("audioUrl").asText();
+        String pathOnly = audioUrl.substring(audioUrl.indexOf("/uploads"));
+
+        // 3. 정적 리소스 핸들러를 통해 파일 접근 시도
+        mockMvc.perform(get(pathOnly))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("audio/mpeg"));
+    }
+
+    @Test
+    @DisplayName("5. 빈 텍스트 요청 시 Validation 에러 테스트")
+    void generateTtsEmptyTextFail() throws Exception {
+        // given
+        TTSRequest request = TTSRequest.builder()
+                .text("") // 빈 값
+                .language("ko-KR")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/tts/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #12

## ✨ 작업 내용 요약
- TTS(Text-To-Speech) 생성 API 구현
  - 텍스트를 음성으로 변환하는 API 추가 (`POST /api/tts/generate`)
  - 한국어·부모 언어 기반 다국어 TTS 지원 (ko-KR, vi-VN, en-US 등)
- 동화 생성 흐름과 TTS 자동 연동
  - `POST /api/stories/generate` 과정에서 슬라이드 단위로 TTS 자동 생성
  - 생성된 오디오 URL을 슬라이드 데이터에 포함하여 저장
    - `audio_url_kr`, `audio_url_native` 필드 사용
- TTS 구조 분리 및 확장성 고려
  - TTSService 인터페이스 기반으로 구현하여 TTS 엔진 교체 가능 구조 설계
  - 개발/테스트용 Mock TTS와 실제 운영용 TTS 분리
  - 슬라이드/동화 단위 TTS 재생성 API 제공
    - `POST /api/tts/regenerate/slide/{slideId}`
    - `POST /api/tts/regenerate/story/{storyId}`
    - `POST /api/tts/regenerate/missing/{storyId}`
- 안정성 및 성능 개선
  - TTS 생성 실패 시 전체 플로우를 중단하지 않도록 예외 처리 및 로그 처리
  - 동화 다수 슬라이드 처리 시 병목 방지를 위해 비동기 처리 적용

## 🗒️ 참고 사항
- TTS API는 음성 파일 자체가 아닌 오디오 URL을 반환하며, 동화 글과 이미지 역시 AI 서버에서 생성되어 이미지 URL 형태로 함께 전달받는 방식
- Google TTS 사용을 위해 GCP 서비스 계정 키(json) 설정 필요
- 로컬 환경에서는 dev 프로필을 통해 Mock 서비스로 테스트 가능
- 현재는 로컬 스토리지 기반 -> 추후 Google Cloud Storage(GCS) 등 클라우드 스토리지로 확장 예정
- 지원하지 않는 언어 코드는 예외 처리
- 백엔드 기준 구현 및 통합 테스트 완료 상태 -> 프론트·AI 연동 후 추가 검증 예정