### PR TITLE
Feat/7-onboarding- profile

### DIFF
--- a/src/main/java/com/moretale/domain/profile/controller/UserProfileController.java
+++ b/src/main/java/com/moretale/domain/profile/controller/UserProfileController.java
@@ -1,8 +1,6 @@
 package com.moretale.domain.profile.controller;
 
-import com.moretale.domain.profile.dto.LanguageUpdateRequest;
-import com.moretale.domain.profile.dto.UserProfileRequest;
-import com.moretale.domain.profile.dto.UserProfileResponse;
+import com.moretale.domain.profile.dto.*;
 import com.moretale.domain.profile.service.UserProfileService;
 import com.moretale.global.common.ApiResponse;
 import com.moretale.global.security.UserPrincipal;
@@ -27,6 +25,26 @@ public class UserProfileController {
 
     private final UserProfileService userProfileService;
 
+    // 온보딩용 프로필 생성
+    //최초 로그인 후 단계별 질문에 따라 상세 프로필을 생성
+    @PostMapping("/onboarding")
+    @Operation(summary = "온보딩 프로필 생성", description = "최초 로그인 후 단계별 질문에 따라 프로필을 생성합니다.")
+    public ResponseEntity<ApiResponse<OnboardingProfileResponse>> createOnboardingProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody OnboardingProfileRequest request) {
+
+        log.info("온보딩 프로필 생성 요청 - userId: {}", userPrincipal.getUserId());
+
+        OnboardingProfileResponse response = userProfileService.createOnboardingProfile(
+                userPrincipal.getUserId(), request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "프로필 설정이 완료되었습니다!"));
+    }
+
+    // 프로필 생성 (기본/추가)
+    //사용자 자녀 프로필을 생성합니다. (1:N 지원)
     @PostMapping
     @Operation(summary = "프로필 생성", description = "사용자 자녀 프로필을 생성합니다. (1:N 지원)")
     public ResponseEntity<ApiResponse<UserProfileResponse>> createProfile(
@@ -43,6 +61,7 @@ public class UserProfileController {
                 .body(ApiResponse.success(response, "프로필이 생성되었습니다."));
     }
 
+    // 전체 프로필 목록 조회
     @GetMapping("/list")
     @Operation(summary = "전체 프로필 목록 조회", description = "현재 로그인한 사용자의 모든 자녀 프로필 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<UserProfileResponse>>> getAllProfiles(
@@ -55,44 +74,57 @@ public class UserProfileController {
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
+    // 특정 프로필 상세 조회
     @GetMapping("/{profileId}")
     @Operation(summary = "특정 프로필 상세 조회", description = "프로필 고유 ID(profileId)를 기준으로 상세 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(
-            @PathVariable("profileId") Long profileId) { // 명시적 이름 지정
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable("profileId") Long profileId) {
 
-        log.info("프로필 상세 조회 요청 - profileId: {}", profileId);
+        log.info("프로필 상세 조회 요청 - userId: {}, profileId: {}", userPrincipal.getUserId(), profileId);
 
+        // 보안을 위해 서비스단에서 해당 사용자의 프로필인지 확인하는 로직이 권장됩니다.
         UserProfileResponse response = userProfileService.getProfile(profileId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PatchMapping("/{profileId}")
-    @Operation(summary = "프로필 수정", description = "특정 자녀 프로필 정보를 수정합니다.")
+    // 프로필 수정 (전체 정보 수정 - PUT)
+    // 마이페이지 등에서 자녀의 정보를 수정할 때 사용
+    @PutMapping("/{profileId}")
+    @Operation(summary = "프로필 수정", description = "특정 자녀 프로필 정보 전체를 수정합니다.")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateProfile(
-            @PathVariable("profileId") Long profileId, // 명시적 이름 지정
-            @Valid @RequestBody UserProfileRequest request) {
+            @PathVariable("profileId") Long profileId,
+            @Valid @RequestBody UserProfileRequest request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-        log.info("프로필 수정 요청 - profileId: {}", profileId);
+        Long userId = userPrincipal.getUserId();
+        log.info("프로필 수정 요청 - userId: {}, profileId: {}", userId, profileId);
 
-        UserProfileResponse response = userProfileService.updateProfile(profileId, request);
+        // 유저 ID와 프로필 ID를 매칭하여 보안 검증 후 수정
+        UserProfileResponse response = userProfileService.updateProfile(userId, profileId, request);
 
-        return ResponseEntity.ok(ApiResponse.success(response, "프로필이 수정되었습니다."));
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "프로필이 수정되었습니다.")
+        );
     }
 
+    // 언어 설정만 수정 (부분 수정 - PATCH)
     @PatchMapping("/{profileId}/language")
     @Operation(summary = "언어 설정 수정", description = "특정 프로필의 이중언어 설정만 변경합니다.")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateLanguage(
-            @PathVariable("profileId") Long profileId, // 명시적 이름 지정
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable("profileId") Long profileId,
             @Valid @RequestBody LanguageUpdateRequest request) {
 
-        log.info("언어 설정 수정 요청 - profileId: {}", profileId);
+        log.info("언어 설정 수정 요청 - userId: {}, profileId: {}", userPrincipal.getUserId(), profileId);
 
         UserProfileResponse response = userProfileService.updateLanguage(profileId, request);
 
         return ResponseEntity.ok(ApiResponse.success(response, "언어 설정이 변경되었습니다."));
     }
 
+    // 프로필 존재 여부 확인 (최초 온보딩 리다이렉트 판단용)
     @GetMapping("/exists")
     @Operation(summary = "프로필 존재 여부", description = "최소 하나 이상의 자녀 프로필이 설정되어 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Boolean>> hasProfile(
@@ -103,12 +135,15 @@ public class UserProfileController {
         return ResponseEntity.ok(ApiResponse.success(exists));
     }
 
+    // 프로필 삭제
     @DeleteMapping("/{profileId}")
     @Operation(summary = "프로필 삭제", description = "특정 자녀 프로필을 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deleteProfile(
-            @PathVariable("profileId") Long profileId) { // 명시적 이름 지정
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable("profileId") Long profileId) {
 
-        log.info("프로필 삭제 요청 - profileId: {}", profileId);
+        log.info("프로필 삭제 요청 - userId: {}, profileId: {}", userPrincipal.getUserId(), profileId);
+
         userProfileService.deleteProfile(profileId);
         return ResponseEntity.ok(ApiResponse.success(null, "프로필이 삭제되었습니다."));
     }

--- a/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileRequest.java
@@ -1,0 +1,154 @@
+package com.moretale.domain.profile.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OnboardingProfileRequest {
+
+    // 1단계: 주인공(아이) 소개
+    @NotBlank(message = "아이 이름은 필수입니다.")
+    @Size(max = 50, message = "아이 이름은 50자 이하여야 합니다.")
+    private String childName;
+
+    @NotNull(message = "아이 나이는 필수입니다.")
+    private AgeGroup ageGroup; // 0-2세, 3-4세, 5-6세, 7-8세, 10세이상
+
+    // 2단계: 주인공이 쓰는 말이에요
+    @NotBlank(message = "첫 번째 언어는 필수입니다.")
+    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (ex. ko, en)")
+    private String firstLanguage; // 첫 번째 말 (주 사용 언어)
+
+    @NotNull(message = "첫 번째 언어 숙련도는 필수입니다.")
+    private LanguageProficiency firstLanguageProficiency; // 애벌레, 번데기, 나비
+
+    @NotBlank(message = "두 번째 언어는 필수입니다.")
+    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다")
+    private String secondLanguage; // 두 번째 말
+
+    @NotNull(message = "두 번째 언어 숙련도는 필수입니다.")
+    private LanguageProficiency secondLanguageProficiency;
+
+    // 3단계: 이 언어로 어느 정도 말할 수 있나요?
+    @NotNull(message = "첫 번째 언어 듣기 숙련도는 필수입니다.")
+    private LanguageProficiency firstLanguageListening;
+
+    @NotNull(message = "첫 번째 언어 말하기 숙련도는 필수입니다.")
+    private LanguageProficiency firstLanguageSpeaking;
+
+    @NotNull(message = "두 번째 언어 듣기 숙련도는 필수입니다.")
+    private LanguageProficiency secondLanguageListening;
+
+    @NotNull(message = "두 번째 언어 말하기 숙련도는 필수입니다.")
+    private LanguageProficiency secondLanguageSpeaking;
+
+    // 4단계: 함께 사는 사람들
+    @NotNull(message = "함께 사는 사람 정보는 필수입니다.")
+    private FamilyStructure familyStructure; // 한 분과 살아요, 두 분과 살아요, 다른 가족과 살아요, 비밀이에요, 직접 작성
+
+    private String customFamilyStructure; // 직접 작성 시 사용
+
+    // 5단계: 어떤 이야기가 좋아요
+    @NotNull(message = "선호하는 이야기 유형은 필수입니다.")
+    private StoryPreference storyPreference; // 포근포근한 이야기, 신나는 모험 이야기, 오늘 하루를 담은 이야기, 직접 작성
+
+    private String customStoryPreference; // 직접 작성 시 사용
+
+    // 부가 정보 (선택)
+    private String childNationality;
+    private String parentCountry;
+
+    // Enum 정의
+    public enum AgeGroup {
+        AGE_0_2("0-2세"),
+        AGE_3_4("3-4세"),
+        AGE_5_6("5-6세"),
+        AGE_7_8("7-8세"),
+        AGE_10_PLUS("10세 이상");
+
+        private final String description;
+
+        AgeGroup(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        // 나이 그룹에서 중간값 반환 (동화 생성 시 참고용)
+        public int getRepresentativeAge() {
+            return switch (this) {
+                case AGE_0_2 -> 1;
+                case AGE_3_4 -> 3;
+                case AGE_5_6 -> 5;
+                case AGE_7_8 -> 7;
+                case AGE_10_PLUS -> 10;
+            };
+        }
+    }
+
+    public enum LanguageProficiency {
+        CATERPILLAR("애벌레"), // 초급
+        CHRYSALIS("번데기"),   // 중급
+        BUTTERFLY("나비");     // 고급
+
+        private final String description;
+
+        LanguageProficiency(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        // 숙련도를 숫자로 변환 (1~3)
+        public int getLevel() {
+            return switch (this) {
+                case CATERPILLAR -> 1;
+                case CHRYSALIS -> 2;
+                case BUTTERFLY -> 3;
+            };
+        }
+    }
+
+    public enum FamilyStructure {
+        ONE_PARENT("한 분과 살아요"),
+        TWO_PARENTS("두 분과 살아요"),
+        EXTENDED_FAMILY("다른 가족과 살아요"),
+        SECRET("비밀이에요"),
+        CUSTOM("직접 작성해요");
+
+        private final String description;
+
+        FamilyStructure(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    public enum StoryPreference {
+        WARM("포근포근한 이야기"),
+        ADVENTURE("신나는 모험 이야기"),
+        DAILY("오늘 하루를 담은 이야기"),
+        CUSTOM("직접 작성해요");
+
+        private final String description;
+
+        StoryPreference(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileResponse.java
+++ b/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileResponse.java
@@ -1,0 +1,81 @@
+package com.moretale.domain.profile.dto;
+
+import com.moretale.domain.profile.dto.OnboardingProfileRequest.*;
+import com.moretale.domain.profile.entity.UserProfile;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OnboardingProfileResponse {
+
+    private Long profileId;
+    private Long userId;
+    private String nickname;
+    private String childName;
+    private AgeGroup ageGroup;
+    private Integer childAge; // 실제 나이 (대표값)
+
+    // 언어 설정
+    private String firstLanguage;
+    private LanguageProficiency firstLanguageProficiency;
+    private String secondLanguage;
+    private LanguageProficiency secondLanguageProficiency;
+
+    // 언어 능력 (듣기/말하기)
+    private LanguageProficiency firstLanguageListening;
+    private LanguageProficiency firstLanguageSpeaking;
+    private LanguageProficiency secondLanguageListening;
+    private LanguageProficiency secondLanguageSpeaking;
+
+    // 가족 구조
+    private FamilyStructure familyStructure;
+    private String customFamilyStructure;
+
+    // 이야기 선호도
+    private StoryPreference storyPreference;
+    private String customStoryPreference;
+
+    // 부가 정보
+    private String childNationality;
+    private String parentCountry;
+
+    // 생성/수정 시각
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static OnboardingProfileResponse fromEntity(UserProfile profile) {
+        if (profile == null || profile.getUser() == null) {
+            throw new IllegalArgumentException("Profile or User cannot be null");
+        }
+
+        return OnboardingProfileResponse.builder()
+                .profileId(profile.getProfileId())
+                .userId(profile.getUser().getUserId())
+                .nickname(profile.getUser().getNickname())
+                .childName(profile.getChildName())
+                .ageGroup(profile.getAgeGroup())
+                .childAge(profile.getChildAge())
+                .firstLanguage(profile.getFirstLanguage())
+                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
+                .secondLanguage(profile.getSecondLanguage())
+                .secondLanguageProficiency(profile.getSecondLanguageProficiency())
+                .firstLanguageListening(profile.getFirstLanguageListening())
+                .firstLanguageSpeaking(profile.getFirstLanguageSpeaking())
+                .secondLanguageListening(profile.getSecondLanguageListening())
+                .secondLanguageSpeaking(profile.getSecondLanguageSpeaking())
+                .familyStructure(profile.getFamilyStructure())
+                .customFamilyStructure(profile.getCustomFamilyStructure())
+                .storyPreference(profile.getStoryPreference())
+                .customStoryPreference(profile.getCustomStoryPreference())
+                .childNationality(profile.getChildNationality())
+                .parentCountry(profile.getParentCountry())
+                .createdAt(profile.getCreatedAt())
+                .updatedAt(profile.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/profile/dto/UserProfileRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/UserProfileRequest.java
@@ -1,5 +1,7 @@
 package com.moretale.domain.profile.dto;
 
+import com.moretale.domain.profile.dto.OnboardingProfileRequest.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
@@ -8,29 +10,85 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "사용자 프로필 요청 DTO (생성/수정)")
 public class UserProfileRequest {
 
     @NotBlank(message = "아이 이름은 필수입니다.")
-    @Size(max = 50, message = "아이 이름은 50자 이하여야 합니다.")
+    @Size(max = 50, message = "아이 이름은 50자 이하로 입력해주세요.")
+    @Schema(description = "아이 이름", example = "민준")
     private String childName;
 
-    @NotNull(message = "아이 나이는 필수입니다.")
-    @Min(value = 1, message = "아이 나이는 1세 이상이어야 합니다.")
-    @Max(value = 18, message = "아이 나이는 18세 이하여야 합니다.")
-    private Integer childAge;
+    @NotNull(message = "나이 그룹은 필수입니다.")
+    @Schema(description = "나이 그룹 (AGE_0_2, AGE_3_4, AGE_5_6, AGE_7_8, AGE_10_PLUS)", example = "AGE_5_6")
+    private AgeGroup ageGroup;
 
-    @Size(max = 50, message = "자녀 국적은 50자 이하여야 합니다.")
+    @NotBlank(message = "제1언어는 필수입니다.")
+    @Schema(description = "제1언어 (ISO 639-1 코드)", example = "ko")
+    private String firstLanguage;
+
+    @NotNull(message = "제1언어 숙련도는 필수입니다.")
+    @Schema(description = "제1언어 전체 숙련도 (CATERPILLAR, CHRYSALIS, BUTTERFLY)", example = "BUTTERFLY")
+    private LanguageProficiency firstLanguageProficiency;
+
+    @NotBlank(message = "제2언어는 필수입니다.")
+    @Schema(description = "제2언어 (ISO 639-1 코드)", example = "vi")
+    private String secondLanguage;
+
+    @NotNull(message = "제2언어 숙련도는 필수입니다.")
+    @Schema(description = "제2언어 전체 숙련도 (CATERPILLAR, CHRYSALIS, BUTTERFLY)", example = "CATERPILLAR")
+    private LanguageProficiency secondLanguageProficiency;
+
+    @NotNull(message = "제1언어 듣기 능력은 필수입니다.")
+    @Schema(description = "제1언어 듣기 능력", example = "BUTTERFLY")
+    private LanguageProficiency firstLanguageListening;
+
+    @NotNull(message = "제1언어 말하기 능력은 필수입니다.")
+    @Schema(description = "제1언어 말하기 능력", example = "BUTTERFLY")
+    private LanguageProficiency firstLanguageSpeaking;
+
+    @NotNull(message = "제2언어 듣기 능력은 필수입니다.")
+    @Schema(description = "제2언어 듣기 능력", example = "CHRYSALIS")
+    private LanguageProficiency secondLanguageListening;
+
+    @NotNull(message = "제2언어 말하기 능력은 필수입니다.")
+    @Schema(description = "제2언어 말하기 능력", example = "CATERPILLAR")
+    private LanguageProficiency secondLanguageSpeaking;
+
+    @NotNull(message = "가족 구조는 필수입니다.")
+    @Schema(description = "가족 구조 (ONE_PARENT, TWO_PARENTS, EXTENDED_FAMILY, SECRET, CUSTOM)", example = "TWO_PARENTS")
+    private FamilyStructure familyStructure;
+
+    @Size(max = 200, message = "커스텀 가족 구조는 200자 이하로 입력해주세요.")
+    @Schema(description = "커스텀 가족 구조 (OTHER 선택 시)")
+    private String customFamilyStructure;
+
+    @NotNull(message = "이야기 선호도는 필수입니다.")
+    @Schema(description = "이야기 선호도 (WARM, ADVENTURE, DAILY, CUSTOM)", example = "ADVENTURE")
+    private StoryPreference storyPreference;
+
+    @Size(max = 200, message = "커스텀 이야기 선호도는 200자 이하로 입력해주세요.")
+    @Schema(description = "커스텀 이야기 선호도 (OTHER 선택 시)")
+    private String customStoryPreference;
+
+    @Size(max = 50, message = "아이 국적은 50자 이하로 입력해주세요.")
+    @Schema(description = "아이 국적 (ISO 3166-1 alpha-2)", example = "KR")
     private String childNationality;
 
-    @NotBlank(message = "부모 출신 국가는 필수입니다.")
-    @Size(max = 50, message = "부모 출신 국가는 50자 이하여야 합니다.")
+    @Size(max = 50, message = "부모 거주 국가는 50자 이하로 입력해주세요.")
+    @Schema(description = "부모 거주 국가 (ISO 3166-1 alpha-2)", example = "VN")
     private String parentCountry;
 
-    @NotBlank(message = "기본 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (예: ko, en)")
+    @Deprecated
+    @Schema(description = "[Deprecated] 기본 언어", example = "ko")
     private String primaryLanguage;
 
-    @NotBlank(message = "부모 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (예: vi, en)")
+    @Deprecated
+    @Schema(description = "[Deprecated] 보조 언어", example = "vi")
     private String secondaryLanguage;
+
+    @Deprecated
+    @Min(value = 1, message = "아이 나이는 1세 이상이어야 합니다.")
+    @Max(value = 12, message = "아이 나이는 12세 이하여야 합니다.")
+    @Schema(description = "[Deprecated] 아이 나이", example = "6")
+    private Integer childAge;
 }

--- a/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
+++ b/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
@@ -1,5 +1,6 @@
 package com.moretale.domain.profile.dto;
 
+import com.moretale.domain.profile.dto.OnboardingProfileRequest.*;
 import com.moretale.domain.profile.entity.UserProfile;
 import lombok.*;
 
@@ -12,25 +13,72 @@ import java.time.LocalDateTime;
 @Builder
 public class UserProfileResponse {
 
-    private Long profileId;      // 프로필 고유 ID
-    private Long userId;         // 부모(User) ID
+    private Long profileId;
+    private Long userId;
     private String nickname;
     private String childName;
     private Integer childAge;
+
+    // === 온보딩 상세 필드 추가 ===
+    private AgeGroup ageGroup;
+
+    // 언어 설정
+    private String firstLanguage;
+    private LanguageProficiency firstLanguageProficiency;
+    private String secondLanguage;
+    private LanguageProficiency secondLanguageProficiency;
+
+    // 언어 능력 (듣기/말하기)
+    private LanguageProficiency firstLanguageListening;
+    private LanguageProficiency firstLanguageSpeaking;
+    private LanguageProficiency secondLanguageListening;
+    private LanguageProficiency secondLanguageSpeaking;
+
+    // 가족 구조
+    private FamilyStructure familyStructure;
+    private String customFamilyStructure;
+
+    // 이야기 선호도
+    private StoryPreference storyPreference;
+    private String customStoryPreference;
+
     private String childNationality;
     private String parentCountry;
+
+    // 하위 호환성 필드 (Deprecated)
+    @Deprecated
     private String primaryLanguage;
+
+    @Deprecated
     private String secondaryLanguage;
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static UserProfileResponse fromEntity(UserProfile profile) {
+        if (profile == null || profile.getUser() == null) {
+            throw new IllegalArgumentException("Profile or User cannot be null");
+        }
+
         return UserProfileResponse.builder()
                 .profileId(profile.getProfileId())
                 .userId(profile.getUser().getUserId())
                 .nickname(profile.getUser().getNickname())
                 .childName(profile.getChildName())
                 .childAge(profile.getChildAge())
+                .ageGroup(profile.getAgeGroup())
+                .firstLanguage(profile.getFirstLanguage())
+                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
+                .secondLanguage(profile.getSecondLanguage())
+                .secondLanguageProficiency(profile.getSecondLanguageProficiency())
+                .firstLanguageListening(profile.getFirstLanguageListening())
+                .firstLanguageSpeaking(profile.getFirstLanguageSpeaking())
+                .secondLanguageListening(profile.getSecondLanguageListening())
+                .secondLanguageSpeaking(profile.getSecondLanguageSpeaking())
+                .familyStructure(profile.getFamilyStructure())
+                .customFamilyStructure(profile.getCustomFamilyStructure())
+                .storyPreference(profile.getStoryPreference())
+                .customStoryPreference(profile.getCustomStoryPreference())
                 .childNationality(profile.getChildNationality())
                 .parentCountry(profile.getParentCountry())
                 .primaryLanguage(profile.getPrimaryLanguage())

--- a/src/main/java/com/moretale/domain/profile/entity/UserProfile.java
+++ b/src/main/java/com/moretale/domain/profile/entity/UserProfile.java
@@ -1,5 +1,6 @@
 package com.moretale.domain.profile.entity;
 
+import com.moretale.domain.profile.dto.OnboardingProfileRequest.*;
 import com.moretale.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,21 +32,78 @@ public class UserProfile {
     @Column(name = "child_name", nullable = false, length = 50)
     private String childName;
 
+    // 나이 그룹 (Enum)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "age_group", nullable = false)
+    private AgeGroup ageGroup;
+
+    // 실제 나이 (대표값, 자동 계산)
     @Column(name = "child_age", nullable = false)
     private Integer childAge;
 
+    // 언어 설정
+    @Column(name = "first_language", nullable = false, length = 10)
+    private String firstLanguage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "first_language_proficiency", nullable = false)
+    private LanguageProficiency firstLanguageProficiency;
+
+    @Column(name = "second_language", nullable = false, length = 10)
+    private String secondLanguage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "second_language_proficiency", nullable = false)
+    private LanguageProficiency secondLanguageProficiency;
+
+    // 언어 능력 (듣기/말하기)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "first_language_listening", nullable = false)
+    private LanguageProficiency firstLanguageListening;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "first_language_speaking", nullable = false)
+    private LanguageProficiency firstLanguageSpeaking;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "second_language_listening", nullable = false)
+    private LanguageProficiency secondLanguageListening;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "second_language_speaking", nullable = false)
+    private LanguageProficiency secondLanguageSpeaking;
+
+    // 가족 구조
+    @Enumerated(EnumType.STRING)
+    @Column(name = "family_structure", nullable = false)
+    private FamilyStructure familyStructure;
+
+    @Column(name = "custom_family_structure", length = 200)
+    private String customFamilyStructure;
+
+    // 이야기 선호도
+    @Enumerated(EnumType.STRING)
+    @Column(name = "story_preference", nullable = false)
+    private StoryPreference storyPreference;
+
+    @Column(name = "custom_story_preference", length = 200)
+    private String customStoryPreference;
+
+    // 부가 정보 (선택)
     @Column(name = "child_nationality", length = 50)
     private String childNationality;
 
-    @Column(name = "parent_country", nullable = false, length = 50)
+    @Column(name = "parent_country", length = 50)
     private String parentCountry;
 
-    @Column(name = "primary_language", nullable = false, length = 10)
-    @Builder.Default
-    private String primaryLanguage = "ko"; // 기본값 한국어
+    // 하위 호환성 유지 (기존 필드)
+    @Deprecated
+    @Column(name = "primary_language", length = 10)
+    private String primaryLanguage;
 
-    @Column(name = "secondary_language", nullable = false, length = 10)
-    private String secondaryLanguage; // 부모의 모국어 (이중언어 설정용)
+    @Deprecated
+    @Column(name = "secondary_language", length = 10)
+    private String secondaryLanguage;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -54,4 +112,66 @@ public class UserProfile {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // 비즈니스 로직
+
+    // 프로필 업데이트
+    public void updateProfile(
+            String childName,
+            AgeGroup ageGroup,
+            String firstLanguage,
+            LanguageProficiency firstLanguageProficiency,
+            String secondLanguage,
+            LanguageProficiency secondLanguageProficiency,
+            LanguageProficiency firstLanguageListening,
+            LanguageProficiency firstLanguageSpeaking,
+            LanguageProficiency secondLanguageListening,
+            LanguageProficiency secondLanguageSpeaking,
+            FamilyStructure familyStructure,
+            String customFamilyStructure,
+            StoryPreference storyPreference,
+            String customStoryPreference,
+            String childNationality,
+            String parentCountry
+    ) {
+        this.childName = childName;
+        this.ageGroup = ageGroup;
+        // 나이 그룹의 대표값으로 childAge 갱신
+        this.childAge = ageGroup.getRepresentativeAge();
+        this.firstLanguage = firstLanguage;
+        this.firstLanguageProficiency = firstLanguageProficiency;
+        this.secondLanguage = secondLanguage;
+        this.secondLanguageProficiency = secondLanguageProficiency;
+        this.firstLanguageListening = firstLanguageListening;
+        this.firstLanguageSpeaking = firstLanguageSpeaking;
+        this.secondLanguageListening = secondLanguageListening;
+        this.secondLanguageSpeaking = secondLanguageSpeaking;
+        this.familyStructure = familyStructure;
+        this.customFamilyStructure = customFamilyStructure;
+        this.storyPreference = storyPreference;
+        this.customStoryPreference = customStoryPreference;
+        this.childNationality = childNationality;
+        this.parentCountry = parentCountry;
+
+        // 하위 호환성 필드 동기화
+        syncLegacyLanguages();
+
+        // updatedAt 명시적 갱신 (Hibernate가 처리하지만 명확성을 위해 유지)
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 나이 그룹에서 실제 나이 자동 계산 (@PrePersist / @PreUpdate)
+    @PrePersist
+    @PreUpdate
+    public void calculateChildAge() {
+        if (this.ageGroup != null) {
+            this.childAge = this.ageGroup.getRepresentativeAge();
+        }
+    }
+
+    // 하위 호환성: primaryLanguage/secondaryLanguage 자동 동기화
+    public void syncLegacyLanguages() {
+        this.primaryLanguage = this.firstLanguage;
+        this.secondaryLanguage = this.secondLanguage;
+    }
 }

--- a/src/main/java/com/moretale/domain/profile/service/UserProfileService.java
+++ b/src/main/java/com/moretale/domain/profile/service/UserProfileService.java
@@ -1,8 +1,6 @@
 package com.moretale.domain.profile.service;
 
-import com.moretale.domain.profile.dto.LanguageUpdateRequest;
-import com.moretale.domain.profile.dto.UserProfileRequest;
-import com.moretale.domain.profile.dto.UserProfileResponse;
+import com.moretale.domain.profile.dto.*;
 import com.moretale.domain.profile.entity.UserProfile;
 import com.moretale.domain.profile.repository.UserProfileRepository;
 import com.moretale.domain.user.entity.User;
@@ -26,7 +24,50 @@ public class UserProfileService {
     private final UserProfileRepository userProfileRepository;
     private final UserRepository userRepository;
 
-    // 프로필 추가
+    // 온보딩용 프로필 생성
+    @Transactional
+    public OnboardingProfileResponse createOnboardingProfile(Long userId, OnboardingProfileRequest request) {
+        log.info("온보딩 프로필 생성 시작 - userId: {}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 동일한 이름의 아이가 이미 등록되어 있는지 체크
+        if (userProfileRepository.existsByUser_UserIdAndChildName(userId, request.getChildName())) {
+            throw new CustomException(ErrorCode.PROFILE_ALREADY_EXISTS);
+        }
+
+        UserProfile profile = UserProfile.builder()
+                .user(user)
+                .childName(request.getChildName())
+                .ageGroup(request.getAgeGroup())
+                .firstLanguage(request.getFirstLanguage())
+                .firstLanguageProficiency(request.getFirstLanguageProficiency())
+                .secondLanguage(request.getSecondLanguage())
+                .secondLanguageProficiency(request.getSecondLanguageProficiency())
+                .firstLanguageListening(request.getFirstLanguageListening())
+                .firstLanguageSpeaking(request.getFirstLanguageSpeaking())
+                .secondLanguageListening(request.getSecondLanguageListening())
+                .secondLanguageSpeaking(request.getSecondLanguageSpeaking())
+                .familyStructure(request.getFamilyStructure())
+                .customFamilyStructure(request.getCustomFamilyStructure())
+                .storyPreference(request.getStoryPreference())
+                .customStoryPreference(request.getCustomStoryPreference())
+                .childNationality(request.getChildNationality())
+                .parentCountry(request.getParentCountry())
+                .build();
+
+        // 하위 호환성 유지 (primary/secondaryLanguage 세팅)
+        profile.syncLegacyLanguages();
+
+        UserProfile savedProfile = userProfileRepository.save(profile);
+        log.info("온보딩 프로필 생성 완료 - profileId: {}, childName: {}",
+                savedProfile.getProfileId(), savedProfile.getChildName());
+
+        return OnboardingProfileResponse.fromEntity(savedProfile);
+    }
+
+    // 기본 프로필 생성
     @Transactional
     public UserProfileResponse createProfile(Long userId, UserProfileRequest request) {
         log.info("프로필 생성 시작 - userId: {}", userId);
@@ -42,16 +83,27 @@ public class UserProfileService {
         UserProfile profile = UserProfile.builder()
                 .user(user)
                 .childName(request.getChildName())
-                .childAge(request.getChildAge())
+                .ageGroup(request.getAgeGroup())
+                .firstLanguage(request.getFirstLanguage())
+                .firstLanguageProficiency(request.getFirstLanguageProficiency())
+                .secondLanguage(request.getSecondLanguage())
+                .secondLanguageProficiency(request.getSecondLanguageProficiency())
+                .firstLanguageListening(request.getFirstLanguageListening())
+                .firstLanguageSpeaking(request.getFirstLanguageSpeaking())
+                .secondLanguageListening(request.getSecondLanguageListening())
+                .secondLanguageSpeaking(request.getSecondLanguageSpeaking())
+                .familyStructure(request.getFamilyStructure())
+                .customFamilyStructure(request.getCustomFamilyStructure())
+                .storyPreference(request.getStoryPreference())
+                .customStoryPreference(request.getCustomStoryPreference())
                 .childNationality(request.getChildNationality())
                 .parentCountry(request.getParentCountry())
-                .primaryLanguage(request.getPrimaryLanguage())
-                .secondaryLanguage(request.getSecondaryLanguage())
                 .build();
 
+        profile.syncLegacyLanguages();
+
         UserProfile savedProfile = userProfileRepository.save(profile);
-        log.info("프로필 생성 완료 - userId: {}, profileId: {}, childName: {}",
-                userId, savedProfile.getProfileId(), savedProfile.getChildName());
+        log.info("프로필 생성 완료 - profileId: {}", savedProfile.getProfileId());
 
         return UserProfileResponse.fromEntity(savedProfile);
     }
@@ -77,18 +129,43 @@ public class UserProfileService {
 
     // 프로필 정보 수정 (profileId 기준)
     @Transactional
-    public UserProfileResponse updateProfile(Long profileId, UserProfileRequest request) {
-        log.info("프로필 수정 시작 - profileId: {}", profileId);
+    public UserProfileResponse updateProfile(Long userId, Long profileId, UserProfileRequest request) {
+        log.info("프로필 수정 시작 - userId: {}, profileId: {}", userId, profileId);
 
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 프로필 존재 확인
         UserProfile profile = userProfileRepository.findById(profileId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND));
 
-        profile.setChildName(request.getChildName());
-        profile.setChildAge(request.getChildAge());
-        profile.setChildNationality(request.getChildNationality());
-        profile.setParentCountry(request.getParentCountry());
-        profile.setPrimaryLanguage(request.getPrimaryLanguage());
-        profile.setSecondaryLanguage(request.getSecondaryLanguage());
+        // 본인의 프로필인지 권한 확인
+        if (!profile.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        // 프로필 업데이트 메서드 사용
+        profile.updateProfile(
+                request.getChildName(),
+                request.getAgeGroup(),
+                request.getFirstLanguage(),
+                request.getFirstLanguageProficiency(),
+                request.getSecondLanguage(),
+                request.getSecondLanguageProficiency(),
+                request.getFirstLanguageListening(),
+                request.getFirstLanguageSpeaking(),
+                request.getSecondLanguageListening(),
+                request.getSecondLanguageSpeaking(),
+                request.getFamilyStructure(),
+                request.getCustomFamilyStructure(),
+                request.getStoryPreference(),
+                request.getCustomStoryPreference(),
+                request.getChildNationality(),
+                request.getParentCountry()
+        );
+
+        log.info("프로필 수정 완료 - profileId: {}, childName: {}", profile.getProfileId(), profile.getChildName());
 
         return UserProfileResponse.fromEntity(profile);
     }

--- a/src/main/java/com/moretale/global/exception/ErrorCode.java
+++ b/src/main/java/com/moretale/global/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
 
     // 프로필 (Profile)
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로필을 찾을 수 없습니다."),
-    PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "P002", "이미 프로필이 존재합니다."),
+    PROFILE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P002", "접근 권한이 없습니다."),
+    PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "P003", "이미 프로필이 존재합니다."),
 
     // 동화 (Story)
     STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "동화를 찾을 수 없습니다."),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,36 +1,18 @@
--- users 테이블 더미 데이터
-INSERT INTO users (email, nickname, region, role, provider, provider_id, created_at)
-SELECT 'testuser@example.com', 'testmom', '서울', 'USER', 'google', 'google-1234', NOW()
-WHERE NOT EXISTS (
-    SELECT 1 FROM users WHERE email = 'testuser@example.com'
-);
-
-INSERT INTO users (email, nickname, region, role, provider, provider_id, created_at)
-SELECT 'admin@moretale.com', 'admin', '서울', 'ADMIN', 'google', 'google-admin', NOW()
-WHERE NOT EXISTS (
-    SELECT 1 FROM users WHERE email = 'admin@moretale.com'
-);
-
--- user_profiles 테이블 더미 데이터
 INSERT INTO user_profiles (
-    user_id,
-    child_name,
-    child_age,
-    child_nationality,
-    parent_country,
-    primary_language,
-    secondary_language,
+    user_id, child_name, age_group, child_age, child_nationality, parent_country,
+    first_language, first_language_proficiency, second_language, second_language_proficiency,
+    first_language_listening, first_language_speaking, second_language_listening, second_language_speaking,
+    family_structure, story_preference,
+    primary_language, secondary_language,
     created_at
 )
 SELECT
-    u.user_id,
-    '민준',
-    6,
-    '대한민국',
-    '베트남',
-    'ko',
-    'vi',
+    u.user_id, '민준', 'AGE_5_6', 6, '대한민국', '베트남',
+    'ko', 'BUTTERFLY', 'vi', 'CATERPILLAR',
+    'BUTTERFLY', 'BUTTERFLY', 'CHRYSALIS', 'CATERPILLAR',
+    'TWO_PARENTS', 'WARM',
+    'ko', 'vi',
     NOW()
 FROM users u
 WHERE u.email = 'testuser@example.com'
-  AND NOT EXISTS (SELECT 1 FROM user_profiles WHERE user_id = u.user_id);
+AND NOT EXISTS (SELECT 1 FROM user_profiles WHERE user_id = u.user_id);

--- a/src/main/resources/db/migration/V2__add_onboarding_profile_fields.sql
+++ b/src/main/resources/db/migration/V2__add_onboarding_profile_fields.sql
@@ -1,0 +1,24 @@
+-- UserProfile 테이블 구조 변경 (PostgreSQL)
+ALTER TABLE user_profiles
+    -- 1. 나이 그룹 추가
+    ADD COLUMN age_group VARCHAR(20),
+
+    -- 2. 언어 설정 및 능력 추가
+    ADD COLUMN first_language VARCHAR(10),
+    ADD COLUMN first_language_proficiency VARCHAR(20),
+    ADD COLUMN second_language VARCHAR(10),
+    ADD COLUMN second_language_proficiency VARCHAR(20),
+    ADD COLUMN first_language_listening VARCHAR(20),
+    ADD COLUMN first_language_speaking VARCHAR(20),
+    ADD COLUMN second_language_listening VARCHAR(20),
+    ADD COLUMN second_language_speaking VARCHAR(20),
+
+    -- 3. 가족 구조 및 선호도 추가
+    ADD COLUMN family_structure VARCHAR(30),
+    ADD COLUMN custom_family_structure VARCHAR(200),
+    ADD COLUMN story_preference VARCHAR(30),
+    ADD COLUMN custom_story_preference VARCHAR(200),
+
+    -- 4. 기존 컬럼 제약 조건 수정 (PostgreSQL 문법)
+    ALTER COLUMN primary_language DROP NOT NULL,
+    ALTER COLUMN secondary_language DROP NOT NULL;


### PR DESCRIPTION
## 📌 관련 이슈
- close #14

## ✨ 작업 내용 요약
- 온보딩 전용 프로필 설정 API 추가
  - 최초 로그인 후 단계별 질문 데이터를 한 번에 저장하는 온보딩 전용 API 추가 (`POST /api/users/profile/onboarding`)
  - 나이 그룹, 상세 언어 능력(듣기/말하기), 가족 구조, 이야기 선호도 등 세분화된 데이터 수집 구조
- 신규 유저 자동 리다이렉트
  - 로그인이 성공하면 시스템이 자동으로 유저를 체크
  - 처음 회원가입한 유저 : 자동으로 온보딩 설정 페이지로 이동
  - 회원가입/로그인 기록이 있는 유저 : 바로 메인 홈 화면으로 이동
- 데이터 저장 구조 확장 (PostgreSQL)
  -  아이의 성장 단계와 언어 실력을 더 자세히 기록할 수 있도록 DB 구조 확장
    - 나이 그룹 : 0-2세, 3-4세 등 선택형 구조
    - 언어 숙련도 : '애벌레-번데기-나비'로 표현되는 상세 레벨
    - 가족 및 취향 : 함께 사는 가족 구성과 좋아하는 동화 스타일 저장
- 기존 기능과의 연결 및 보안 강화
  - 기존에 있던 프로필 조회 및 수정 기능이 새로운 데이터 형식에서도 문제없이 작동하도록 수정
  - 다른 사람의 프로필을 함부로 수정할 수 없도록 본인 인증 확인 로직 추가

## 🗒️ 참고 사항
- 디자인상으로는 5단계의 페이지로 구성되나, 효율성을 위해 마지막 단계에서 모든 데이터를 단일 `POST` 요청으로 처리
- 온보딩 완료 직후 AI 추천 동화 자동 생성 기능은 추후 구현 예정