### PR TITLE
Feat/10-vocabulary

### DIFF
--- a/src/main/java/com/moretale/domain/story/dto/TokenResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/TokenResponse.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TokenResponse {
 
+    // 토큰 고정 ID (단어 저장 시 사용될 식별자)
+    private Long id;
+
     // 원문 단어 텍스트 (정규화된 형태, 예: "사자")
     private String text;
 
@@ -30,14 +33,18 @@ public class TokenResponse {
     // 원문 언어 코드 (예: "ko")
     private String sourceLanguage;
 
-    // 번역 언어 코드 (예: "vi")
+    // 번역 언어 코드 (예: "ja", "vi" 등 / highlight=true인 경우에만 존재)
     private String targetLanguage;
 
+    /**
+     * Entity -> DTO 변환 메서드
+     */
     public static TokenResponse from(StoryToken token) {
         return TokenResponse.builder()
+                .id(token.getTokenId()) // token.getId() -> token.getTokenId()로 수정 완료
                 .text(token.getText())
                 .highlight(token.getHighlight())
-                // highlight=false이면 null 반환 (응답 경량화)
+                // highlight=false이면 null을 반환하여 응답 경량화
                 .translation(token.getHighlight() ? token.getTranslation() : null)
                 .definition(token.getHighlight() ? token.getDefinition() : null)
                 .audioUrl(token.getHighlight() ? token.getAudioUrl() : null)

--- a/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
+++ b/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
@@ -1,0 +1,102 @@
+package com.moretale.domain.vocabulary.controller;
+
+import com.moretale.domain.vocabulary.dto.request.VocabularyCreateRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularyPatchRequest;
+import com.moretale.domain.vocabulary.dto.response.VocabularyResponse;
+import com.moretale.domain.vocabulary.dto.response.VocabularyStoryResponse;
+import com.moretale.domain.vocabulary.service.VocabularyService;
+import com.moretale.global.common.ApiResponse;
+import com.moretale.global.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/vocabulary")
+@RequiredArgsConstructor
+public class VocabularyController {
+
+    private final VocabularyService vocabularyService;
+
+    /**
+     * POST /api/vocabulary
+     * 단어 저장
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<VocabularyResponse> save(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody VocabularyCreateRequest request
+    ) {
+        VocabularyResponse response = vocabularyService.save(principal.getUserId(), request);
+        return ApiResponse.success(response, "단어가 단어장에 저장되었습니다.");
+    }
+
+    /**
+     * GET /api/vocabulary
+     * 내 전체 단어장 조회 (페이징)
+     * - storyId 쿼리 파라미터가 있으면 특정 동화 기준 조회
+     */
+    @GetMapping
+    public ApiResponse<Page<VocabularyResponse>> getVocabulary(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(name = "storyId", required = false) Long storyId, // name 명시로 에러 해결
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Page<VocabularyResponse> result = (storyId != null)
+                ? vocabularyService.getByStory(principal.getUserId(), storyId, pageable)
+                : vocabularyService.getAll(principal.getUserId(), pageable);
+
+        return ApiResponse.success(result);
+    }
+
+    /**
+     * GET /api/vocabulary/stories
+     * 단어가 저장된 동화 목록 조회
+     */
+    @GetMapping("/stories")
+    public ApiResponse<List<VocabularyStoryResponse>> getStoriesWithVocabulary(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<VocabularyStoryResponse> result =
+                vocabularyService.getStoriesWithVocabulary(principal.getUserId());
+        return ApiResponse.success(result);
+    }
+
+    /**
+     * PATCH /api/vocabulary/{vocabularyId}
+     * 단어장 항목 수정 (즐겨찾기 / 학습상태 / 메모)
+     */
+    @PatchMapping("/{vocabularyId}")
+    public ApiResponse<VocabularyResponse> patch(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable(name = "vocabularyId") Long vocabularyId, // name 명시
+            @RequestBody VocabularyPatchRequest request
+    ) {
+        VocabularyResponse response =
+                vocabularyService.patch(principal.getUserId(), vocabularyId, request);
+        return ApiResponse.success(response, "단어장이 수정되었습니다.");
+    }
+
+    /**
+     * DELETE /api/vocabulary/{vocabularyId}
+     * 단어 삭제
+     */
+    @DeleteMapping("/{vocabularyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable(name = "vocabularyId") Long vocabularyId // name 명시
+    ) {
+        vocabularyService.delete(principal.getUserId(), vocabularyId);
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularyCreateRequest.java
+++ b/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularyCreateRequest.java
@@ -1,0 +1,28 @@
+package com.moretale.domain.vocabulary.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VocabularyCreateRequest {
+
+    // 저장할 토큰 ID (StoryToken.tokenId)
+    @NotNull(message = "tokenId는 필수입니다.")
+    private Long tokenId;
+
+    // 단어가 속한 슬라이드 ID
+    @NotNull(message = "slideId는 필수입니다.")
+    private Long slideId;
+
+    // 단어가 속한 동화 ID
+    @NotNull(message = "storyId는 필수입니다.")
+    private Long storyId;
+
+    private String word;
+    private String translation;
+    private String definition;
+    private String sourceLanguage;
+    private String targetLanguage;
+}

--- a/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularyPatchRequest.java
+++ b/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularyPatchRequest.java
@@ -1,0 +1,15 @@
+package com.moretale.domain.vocabulary.dto.request;
+
+import com.moretale.domain.vocabulary.entity.VocabularyEntry.LearningStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VocabularyPatchRequest {
+
+    // null이면 변경 안 함
+    private Boolean isFavorite;
+    private LearningStatus learningStatus;
+    private String memo;
+}

--- a/src/main/java/com/moretale/domain/vocabulary/dto/response/VocabularyResponse.java
+++ b/src/main/java/com/moretale/domain/vocabulary/dto/response/VocabularyResponse.java
@@ -1,0 +1,62 @@
+package com.moretale.domain.vocabulary.dto.response;
+
+import com.moretale.domain.vocabulary.entity.VocabularyEntry;
+import com.moretale.domain.vocabulary.entity.VocabularyEntry.LearningStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class VocabularyResponse {
+
+    private Long vocabularyId;
+
+    // 단어 정보
+    private String word;
+    private String normalizedWord;
+    private String translation;
+    private String definition;
+    private String sourceLanguage;
+    private String targetLanguage;
+    private String audioUrl;
+
+    // 출처 정보
+    private Long storyId;
+    private String storyTitle;
+    private Long slideId;
+    private Integer slideOrder;   // 몇 번째 슬라이드인지 (UX 편의)
+    private Long tokenId;
+
+    // 상태 정보
+    private Boolean isFavorite;
+    private LearningStatus learningStatus;
+    private String memo;
+    private LocalDateTime lastReviewedAt;
+
+    private LocalDateTime createdAt;
+
+    public static VocabularyResponse from(VocabularyEntry entry) {
+        return VocabularyResponse.builder()
+                .vocabularyId(entry.getVocabularyId())
+                .word(entry.getWord())
+                .normalizedWord(entry.getNormalizedWord())
+                .translation(entry.getTranslation())
+                .definition(entry.getDefinition())
+                .sourceLanguage(entry.getSourceLanguage())
+                .targetLanguage(entry.getTargetLanguage())
+                .audioUrl(entry.getAudioUrl())
+                .storyId(entry.getStory().getStoryId())
+                .storyTitle(entry.getStory().getTitle())
+                .slideId(entry.getSlide().getSlideId())
+                .slideOrder(entry.getSlide().getOrder())
+                .tokenId(entry.getStoryToken().getTokenId())
+                .isFavorite(entry.getIsFavorite())
+                .learningStatus(entry.getLearningStatus())
+                .memo(entry.getMemo())
+                .lastReviewedAt(entry.getLastReviewedAt())
+                .createdAt(entry.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/dto/response/VocabularyStoryResponse.java
+++ b/src/main/java/com/moretale/domain/vocabulary/dto/response/VocabularyStoryResponse.java
@@ -1,0 +1,31 @@
+package com.moretale.domain.vocabulary.dto.response;
+
+import com.moretale.domain.story.entity.Story;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 단어가 저장된 동화 목록 조회용 DTO
+@Getter
+@Builder
+public class VocabularyStoryResponse {
+
+    private Long storyId;
+    private String title;
+    private String primaryLanguage;
+    private String secondaryLanguage;
+    private LocalDateTime createdAt;   // 도서관 카드 생성일자 표시용
+    private long wordCount;            // 해당 동화에서 저장한 단어 수
+
+    public static VocabularyStoryResponse from(Story story, long wordCount) {
+        return VocabularyStoryResponse.builder()
+                .storyId(story.getStoryId())
+                .title(story.getTitle())
+                .primaryLanguage(story.getPrimaryLanguage())
+                .secondaryLanguage(story.getSecondaryLanguage())
+                .createdAt(story.getCreatedAt())
+                .wordCount(wordCount)
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/entity/VocabularyEntry.java
+++ b/src/main/java/com/moretale/domain/vocabulary/entity/VocabularyEntry.java
@@ -1,0 +1,136 @@
+package com.moretale.domain.vocabulary.entity;
+
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.entity.StoryToken;
+import com.moretale.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "vocabulary_entries",
+        indexes = {
+                @Index(name = "idx_vocab_user_id", columnList = "user_id"),
+                @Index(name = "idx_vocab_story_id", columnList = "story_id"),
+                @Index(name = "idx_vocab_user_story", columnList = "user_id, story_id")
+        }
+)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VocabularyEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vocabulary_id")
+    private Long vocabularyId;
+
+    // 저장한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 단어가 속한 동화 (출처 동화) - 동화 삭제 시 관련 단어 자동 삭제
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Story story;
+
+    // 단어가 속한 슬라이드 (출처 슬라이드) - 슬라이드 삭제 시 관련 단어 자동 삭제
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "slide_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Slide slide;
+
+    // 저장된 StoryToken (원본 토큰 참조) - 토큰 삭제 시 관련 단어 자동 삭제
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "token_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private StoryToken storyToken;
+
+    // 단어 원문 (예: "사자를")
+    @Column(name = "word", nullable = false, length = 100)
+    private String word;
+
+    // 정규화된 단어 (예: "사자") - 중복 판단 기준
+    @Column(name = "normalized_word", nullable = false, length = 100)
+    private String normalizedWord;
+
+    // 번역어
+    @Column(name = "translation", length = 200)
+    private String translation;
+
+    // 단어 뜻 설명
+    @Column(name = "definition", columnDefinition = "TEXT")
+    private String definition;
+
+    // 원문 언어 (예: "ko")
+    @Column(name = "source_language", length = 10)
+    private String sourceLanguage;
+
+    // 번역 대상 언어 (예: "vi")
+    @Column(name = "target_language", length = 10)
+    private String targetLanguage;
+
+    // 단어 발음 오디오 URL
+    @Column(name = "audio_url", length = 500)
+    private String audioUrl;
+
+    // 저장 일시
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // ── 향후 확장 필드 (현재는 미사용, 스키마에만 준비) ──────────────────────
+
+    // 즐겨찾기 여부
+    @Column(name = "is_favorite", nullable = false)
+    @Builder.Default
+    private Boolean isFavorite = false;
+
+    // 학습 상태 (UNSEEN / LEARNING / MASTERED)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "learning_status", length = 20)
+    @Builder.Default
+    private LearningStatus learningStatus = LearningStatus.UNSEEN;
+
+    // 사용자 메모
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo;
+
+    // 마지막 복습 일시
+    @Column(name = "last_reviewed_at")
+    private LocalDateTime lastReviewedAt;
+
+    // ── 편의 메서드 ────────────────────────────────────────────────────────────
+
+    public void updateFavorite(Boolean isFavorite) {
+        this.isFavorite = isFavorite;
+    }
+
+    public void updateLearningStatus(LearningStatus learningStatus) {
+        this.learningStatus = learningStatus;
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public void updateLastReviewedAt(LocalDateTime lastReviewedAt) {
+        this.lastReviewedAt = lastReviewedAt;
+    }
+
+    // 학습 상태 enum
+    public enum LearningStatus {
+        UNSEEN,    // 아직 학습 안 함
+        LEARNING,  // 학습 중
+        MASTERED   // 완전히 익힘
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/exception/TokenNotFoundException.java
+++ b/src/main/java/com/moretale/domain/vocabulary/exception/TokenNotFoundException.java
@@ -1,0 +1,7 @@
+package com.moretale.domain.vocabulary.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+    public TokenNotFoundException(Long tokenId) {
+        super("토큰을 찾을 수 없습니다. tokenId=" + tokenId);
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyAccessDeniedException.java
+++ b/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyAccessDeniedException.java
@@ -1,0 +1,7 @@
+package com.moretale.domain.vocabulary.exception;
+
+public class VocabularyAccessDeniedException extends RuntimeException {
+    public VocabularyAccessDeniedException() {
+        super("해당 단어장 항목에 접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyDuplicateException.java
+++ b/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyDuplicateException.java
@@ -1,0 +1,7 @@
+package com.moretale.domain.vocabulary.exception;
+
+public class VocabularyDuplicateException extends RuntimeException {
+    public VocabularyDuplicateException(String normalizedWord) {
+        super("이미 저장된 단어입니다. word=" + normalizedWord);
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyNotFoundException.java
+++ b/src/main/java/com/moretale/domain/vocabulary/exception/VocabularyNotFoundException.java
@@ -1,0 +1,7 @@
+package com.moretale.domain.vocabulary.exception;
+
+public class VocabularyNotFoundException extends RuntimeException {
+    public VocabularyNotFoundException(Long vocabularyId) {
+        super("단어장 항목을 찾을 수 없습니다. vocabularyId=" + vocabularyId);
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
+++ b/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
@@ -1,0 +1,44 @@
+package com.moretale.domain.vocabulary.repository;
+
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.vocabulary.entity.VocabularyEntry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry, Long> {
+
+    // 내 전체 단어장 조회 (페이징)
+    Page<VocabularyEntry> findByUser_UserId(Long userId, Pageable pageable);
+
+    // 특정 동화 기준 단어장 조회 (페이징)
+    Page<VocabularyEntry> findByUser_UserIdAndStory_StoryId(Long userId, Long storyId, Pageable pageable);
+
+    // 단어가 저장된 동화 목록 조회 (중복 제거)
+    @Query("""
+        SELECT DISTINCT v.story
+        FROM VocabularyEntry v
+        WHERE v.user.userId = :userId
+        ORDER BY v.story.createdAt DESC
+        """)
+    List<Story> findDistinctStoriesByUserId(@Param("userId") Long userId);
+
+    // 단일 항목 조회 (소유권 확인용)
+    Optional<VocabularyEntry> findByVocabularyIdAndUser_UserId(Long vocabularyId, Long userId);
+
+    // 중복 저장 여부 확인 (같은 사용자 + 같은 동화 + 같은 정규화 단어)
+    boolean existsByUser_UserIdAndStory_StoryIdAndNormalizedWord(
+            Long userId, Long storyId, String normalizedWord
+    );
+
+    // 특정 동화의 단어 수 조회
+    long countByUser_UserIdAndStory_StoryId(Long userId, Long storyId);
+
+    // Story 삭제 시 연관된 단어장 전체 삭제용
+    void deleteAllByStory(Story story);
+}

--- a/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
+++ b/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
@@ -1,0 +1,162 @@
+package com.moretale.domain.vocabulary.service;
+
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.entity.StoryToken;
+import com.moretale.domain.story.repository.SlideRepository;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.story.repository.StoryTokenRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.domain.vocabulary.dto.request.VocabularyCreateRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularyPatchRequest;
+import com.moretale.domain.vocabulary.dto.response.VocabularyResponse;
+import com.moretale.domain.vocabulary.dto.response.VocabularyStoryResponse;
+import com.moretale.domain.vocabulary.entity.VocabularyEntry;
+import com.moretale.domain.vocabulary.exception.*;
+import com.moretale.domain.vocabulary.repository.VocabularyEntryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VocabularyService {
+
+    private final VocabularyEntryRepository vocabularyEntryRepository;
+    private final UserRepository userRepository;
+    private final StoryRepository storyRepository;
+    private final SlideRepository slideRepository;
+    private final StoryTokenRepository storyTokenRepository;
+
+    // ── 단어 저장 ─────────────────────────────────────────────────────────────
+
+    @Transactional
+    public VocabularyResponse save(Long userId, VocabularyCreateRequest request) {
+
+        // 1. 연관 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다. userId=" + userId));
+
+        Story story = storyRepository.findById(request.getStoryId())
+                .orElseThrow(() -> new RuntimeException("동화를 찾을 수 없습니다. storyId=" + request.getStoryId()));
+
+        Slide slide = slideRepository.findById(request.getSlideId())
+                .orElseThrow(() -> new RuntimeException("슬라이드를 찾을 수 없습니다. slideId=" + request.getSlideId()));
+
+        StoryToken token = storyTokenRepository.findById(request.getTokenId())
+                .orElseThrow(() -> new TokenNotFoundException(request.getTokenId()));
+
+        // 2. highlight 단어인지 검증 (highlight=false인 토큰은 단어장 저장 불가)
+        if (!token.getHighlight()) {
+            throw new IllegalArgumentException("하이라이트 단어만 저장할 수 있습니다. tokenId=" + request.getTokenId());
+        }
+
+        // 3. 중복 저장 방지 (같은 사용자 + 같은 동화 + 같은 정규화 단어)
+        String normalizedWord = token.getText().trim().toLowerCase();
+        if (vocabularyEntryRepository.existsByUser_UserIdAndStory_StoryIdAndNormalizedWord(
+                userId, request.getStoryId(), normalizedWord)) {
+            throw new VocabularyDuplicateException(normalizedWord);
+        }
+
+        // 4. 저장
+        VocabularyEntry entry = VocabularyEntry.builder()
+                .user(user)
+                .story(story)
+                .slide(slide)
+                .storyToken(token)
+                .word(token.getText())
+                .normalizedWord(normalizedWord)
+                .translation(token.getTranslation())
+                .definition(token.getDefinition())
+                .sourceLanguage(token.getSourceLanguage())
+                .targetLanguage(token.getTargetLanguage())
+                .audioUrl(token.getAudioUrl())
+                .build();
+
+        VocabularyEntry saved = vocabularyEntryRepository.save(entry);
+        log.info("단어장 저장 완료 - userId={}, word={}, storyId={}", userId, saved.getWord(), request.getStoryId());
+
+        return VocabularyResponse.from(saved);
+    }
+
+    // ── 전체 단어장 조회 ──────────────────────────────────────────────────────
+
+    public Page<VocabularyResponse> getAll(Long userId, Pageable pageable) {
+        return vocabularyEntryRepository
+                .findByUser_UserId(userId, pageable)
+                .map(VocabularyResponse::from);
+    }
+
+    // ── 특정 동화 기준 단어장 조회 ────────────────────────────────────────────
+
+    public Page<VocabularyResponse> getByStory(Long userId, Long storyId, Pageable pageable) {
+        return vocabularyEntryRepository
+                .findByUser_UserIdAndStory_StoryId(userId, storyId, pageable)
+                .map(VocabularyResponse::from);
+    }
+
+    // ── 단어가 저장된 동화 목록 조회 ──────────────────────────────────────────
+
+    public List<VocabularyStoryResponse> getStoriesWithVocabulary(Long userId) {
+        List<Story> stories = vocabularyEntryRepository.findDistinctStoriesByUserId(userId);
+
+        return stories.stream()
+                .map(story -> {
+                    long wordCount = vocabularyEntryRepository
+                            .countByUser_UserIdAndStory_StoryId(userId, story.getStoryId());
+                    return VocabularyStoryResponse.from(story, wordCount);
+                })
+                .toList();
+    }
+
+    // ── 단어장 항목 수정 (즐겨찾기 / 학습상태 / 메모) ─────────────────────────
+
+    @Transactional
+    public VocabularyResponse patch(Long userId, Long vocabularyId, VocabularyPatchRequest request) {
+        VocabularyEntry entry = findOwnedEntry(userId, vocabularyId);
+
+        if (request.getIsFavorite() != null) {
+            entry.updateFavorite(request.getIsFavorite());
+        }
+        if (request.getLearningStatus() != null) {
+            entry.updateLearningStatus(request.getLearningStatus());
+        }
+        if (request.getMemo() != null) {
+            entry.updateMemo(request.getMemo());
+        }
+
+        log.info("단어장 수정 완료 - userId={}, vocabularyId={}", userId, vocabularyId);
+        return VocabularyResponse.from(entry);
+    }
+
+    // ── 단어 삭제 ─────────────────────────────────────────────────────────────
+
+    @Transactional
+    public void delete(Long userId, Long vocabularyId) {
+        VocabularyEntry entry = findOwnedEntry(userId, vocabularyId);
+        vocabularyEntryRepository.delete(entry);
+        log.info("단어장 삭제 완료 - userId={}, vocabularyId={}", userId, vocabularyId);
+    }
+
+    // ── 내부 공통 메서드 ──────────────────────────────────────────────────────
+
+    // 소유권 확인 후 엔티티 반환 (없으면 404, 권한 없으면 403)
+    private VocabularyEntry findOwnedEntry(Long userId, Long vocabularyId) {
+        // 먼저 존재 여부 확인
+        if (!vocabularyEntryRepository.existsById(vocabularyId)) {
+            throw new VocabularyNotFoundException(vocabularyId);
+        }
+        // 소유권 확인
+        return vocabularyEntryRepository
+                .findByVocabularyIdAndUser_UserId(vocabularyId, userId)
+                .orElseThrow(VocabularyAccessDeniedException::new);
+    }
+}

--- a/src/main/java/com/moretale/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moretale/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.moretale.global.exception;
 
+import com.moretale.domain.vocabulary.exception.*;
 import com.moretale.global.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
@@ -15,7 +19,8 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 비즈니스 로직 예외 처리
+    // ── 1. 비즈니스 / 커스텀 공통 예외 (ErrorCode 기반) ──────────────────────
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
         log.error("BusinessException: {}", e.getMessage());
@@ -39,7 +44,41 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
     }
 
-    // Validation Exception 처리
+    // ── 2. Vocabulary 도메인 전용 예외 (HTTP 상태코드 고정형) ──────────────────
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(VocabularyNotFoundException.class)
+    public ApiResponse<Void> handleVocabularyNotFound(VocabularyNotFoundException e) {
+        log.error("VocabularyNotFoundException: {}", e.getMessage());
+        return ApiResponse.error("VOCABULARY_NOT_FOUND", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(VocabularyAccessDeniedException.class)
+    public ApiResponse<Void> handleVocabularyAccessDenied(VocabularyAccessDeniedException e) {
+        log.error("VocabularyAccessDeniedException: {}", e.getMessage());
+        return ApiResponse.error("VOCABULARY_ACCESS_DENIED", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(VocabularyDuplicateException.class)
+    public ApiResponse<Void> handleVocabularyDuplicate(VocabularyDuplicateException e) {
+        log.error("VocabularyDuplicateException: {}", e.getMessage());
+        return ApiResponse.error("VOCABULARY_DUPLICATE", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(TokenNotFoundException.class)
+    public ApiResponse<Void> handleTokenNotFound(TokenNotFoundException e) {
+        log.error("TokenNotFoundException: {}", e.getMessage());
+        return ApiResponse.error("TOKEN_NOT_FOUND", e.getMessage());
+    }
+
+    // ── 3. 클라이언트 요청 에러 (Validation / JSON Parsing) ──────────────────
+
+    /**
+     * @Valid 검증 실패 시 발생 (필수값 누락 등)
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(
             MethodArgumentNotValidException e) {
@@ -58,7 +97,19 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error("VALIDATION_ERROR", "입력값 검증 실패", errors));
     }
 
-    // 기타 Exception 처리
+    /**
+     * JSON 파싱 에러 (타입 불일치 - String을 Long에 넣으려 할 때 등)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("HttpMessageNotReadableException: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error("INVALID_JSON_FORMAT", "요청 데이터 형식이 올바르지 않습니다. 필드 타입을 확인해주세요."));
+    }
+
+    // ── 4. 기타 예외 (최종 방어선) ──────────────────────────────────────────────
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         // 상세 스택 트레이스는 로그로 남겨 추적 가능하게 함

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -54,6 +54,9 @@ public class SecurityConfig {
                         // 동화 생성 API (인증 필요)
                         .requestMatchers("/api/stories/**").authenticated()
 
+                        // 단어장 API (인증 필요)
+                        .requestMatchers("/api/vocabulary/**").authenticated()
+
                         // 로그인 필요
                         .requestMatchers(HttpMethod.POST, "/api/dictionary/*/bookmark").authenticated()    // 북마크 추가
                         .requestMatchers(HttpMethod.DELETE, "/api/dictionary/*/bookmark").authenticated()  // 북마크 제거


### PR DESCRIPTION
## 📌 관련 이슈
- close #20

## ✨ 작업 내용 요약
- 단어장(Vocabulary) 도메인 설계 및 구현
  - `VocabularyEntry` 엔티티 추가
    - `User`, `Story`, `Slide`, `StoryToken`과의 연관관계 구성
    - `normalizedWord` 기준 중복 저장 방지 로직 반영
    - `isFavorite`, `learningStatus`, `memo`, `lastReviewedAt` 등 확장 필드 포함
- 단어장 API 구현
  - `POST /api/vocabulary` : 하이라이트 단어 저장
    - highlight=false 토큰 저장 방지 로직 추가
    - 동일 사용자 + 동일 동화 + 동일 단어 중복 저장 방지
  - `GET /api/vocabulary` : 전체 단어장 조회 (페이징)
  - `GET /api/vocabulary?storyId={storyId}` : 특정 동화 기준 단어 조회
  - `GET /api/vocabulary/stories` : 단어가 저장된 동화 목록 조회 (동화 카드용)
  - `PATCH /api/vocabulary/{vocabularyId}` : 즐겨찾기 / 학습 상태 / 메모 수정
  - `DELETE /api/vocabulary/{vocabularyId}` : 단어 삭제
- 응답 구조 설계
  - `VocabularyResponse` : 단어 정보 + 출처 정보(Story, Slide) + 상태 정보 통합
  - `VocabularyStoryResponse` : 동화 카드 UI용 DTO (createdAt, wordCount 포함)
- 예외 처리 구조 개선
  - Vocabulary 전용 예외 추가
  - GlobalExceptionHandler에 HTTP 상태코드 기반 처리 추가 (404 / 403 / 409 등)
  - JSON 파싱 에러(`HttpMessageNotReadableException`) 처리 추가
- 토큰 응답 구조 개선
  - `TokenResponse`에 `tokenId` 필드 추가
  - 단어 저장 시 식별자로 활용 가능하도록 수정
  - highlight=false인 경우 불필요한 필드 null 처리
- 보안 설정 추가
  - `/api/vocabulary/**` 경로 인증 필요하도록 SecurityConfig 수정

## 🗒️ 참고 사항
- 단어 저장은 반드시 highlight=true 토큰만 가능하도록 제한
- 단어 중복 판단은 `normalizedWord + user + story` 기준으로 처리
- 라이브러리 카드의 생성일자는 Story.createdAt 기준으로 반환
- 단어장은 “전체 리스트”뿐 아니라 동화 단위로 그룹화된 조회 구조를 기본으로 설계
- 향후 학습 기능 확장을 위해 learningStatus, lastReviewedAt 필드는 스키마에 포함
- 현재 단어 발음(audioUrl), 번역, 뜻 정보는 `StoryToken` 기반으로 저장됩니다.