### PR TITLE
Feat/11-library-vocabulary-enhancement

### DIFF
--- a/src/main/java/com/moretale/domain/story/controller/LibraryController.java
+++ b/src/main/java/com/moretale/domain/story/controller/LibraryController.java
@@ -1,0 +1,121 @@
+package com.moretale.domain.story.controller;
+
+import com.moretale.domain.story.dto.StoryLibraryCardResponse;
+import com.moretale.domain.story.service.LibraryService;
+import com.moretale.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 도서관 API Controller
+ *
+ * ┌──────────────────────────────────────────────────────────────────┐
+ * │  API 명세 (프론트 정렬 UI 연동)                                    │
+ * ├──────────────┬───────────────────────────────────────────────────┤
+ * │  정렬 UI     │  요청 파라미터                                      │
+ * ├──────────────┼───────────────────────────────────────────────────┤
+ * │  최신순      │  GET /api/library?sort=createdAt,desc              │
+ * │  오래된순    │  GET /api/library?sort=createdAt,asc               │
+ * │  가나다순    │  GET /api/library?sort=title,asc                   │
+ * ├──────────────┼───────────────────────────────────────────────────┤
+ * │  삭제        │  DELETE /api/library/{storyId}                     │
+ * │              │  → Story + Slide + StoryToken + VocabularyEntry    │
+ * │              │    전체 삭제 (숨김 아님)                             │
+ * └──────────────┴───────────────────────────────────────────────────┘
+ */
+@Tag(name = "Library", description = "도서관 API - 내 동화 목록 관리")
+@Slf4j
+@RestController
+@RequestMapping("/api/library")
+@RequiredArgsConstructor
+public class LibraryController {
+
+    private final LibraryService libraryService;
+
+    /**
+     * 도서관 목록 조회
+     * GET /api/library
+     * GET /api/library?sort=createdAt,desc  (최신순 - 기본값)
+     * GET /api/library?sort=createdAt,asc   (오래된순)
+     * GET /api/library?sort=title,asc       (가나다순)
+     * GET /api/library?page=0&size=10&sort=createdAt,desc
+     */
+    @Operation(
+            summary = "도서관 목록 조회",
+            description = """
+                    내가 만든 동화 목록을 페이징으로 조회합니다.
+                    
+                    **정렬 파라미터 (sort)**
+                    - `sort=createdAt,desc` : 최신순 (기본값)
+                    - `sort=createdAt,asc`  : 오래된순
+                    - `sort=title,asc`      : 가나다순
+                    
+                    **응답 필드**
+                    - `storyId` : 동화 ID
+                    - `title` : 동화 제목
+                    - `thumbnail` : 첫 번째 슬라이드 이미지 URL
+                    - `primaryLanguage` / `secondaryLanguage` : 언어쌍
+                    - `createdAt` : 생성일시 (ISO 8601)
+                    - `slideCount` : 슬라이드 수
+                    """
+    )
+    @GetMapping
+    public ApiResponse<Page<StoryLibraryCardResponse>> getLibrary(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "페이징 및 정렬 (sort=createdAt,desc | sort=title,asc)")
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        log.info("도서관 조회 - email={}, sort={}", userDetails.getUsername(), pageable.getSort());
+
+        Page<StoryLibraryCardResponse> result = libraryService.getLibrary(
+                userDetails.getUsername(), pageable
+        );
+
+        return ApiResponse.success(result, "도서관 조회 성공");
+    }
+
+    /**
+     * 도서관에서 동화 삭제
+     * DELETE /api/library/{storyId}
+     *
+     * Story 삭제 = 동화 자체 삭제 (숨김 아님)
+     * cascade 삭제: Story → Slide → StoryToken → VocabularyEntry
+     */
+    @Operation(
+            summary = "도서관 동화 삭제",
+            description = """
+                    동화를 완전히 삭제합니다. (숨김이 아닌 영구 삭제)
+                    
+                    **삭제 범위 (연쇄 삭제)**
+                    - Story (동화)
+                    - Slide (슬라이드, JPA cascade)
+                    - StoryToken (단어 토큰, JPA cascade)
+                    - VocabularyEntry (단어장 데이터, DB OnDelete CASCADE)
+                    
+                    본인 소유의 동화만 삭제할 수 있습니다.
+                    """
+    )
+    @DeleteMapping("/{storyId}")
+    public ApiResponse<Void> deleteFromLibrary(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable(name = "storyId") Long storyId
+    ) {
+        log.info("도서관 동화 삭제 요청 - email={}, storyId={}",
+                userDetails.getUsername(), storyId);
+
+        libraryService.deleteFromLibrary(userDetails.getUsername(), storyId);
+
+        return ApiResponse.success(null, "동화가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/moretale/domain/story/dto/StoryLibraryCardResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryLibraryCardResponse.java
@@ -8,37 +8,34 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * 기존 목록 조회용 DTO (내부/공개 동화 목록)
- * - primaryLanguage, secondaryLanguage 필드 추가
- * - thumbnail 추가 (첫 슬라이드 이미지)
- */
+// 도서관 화면 카드 응답 DTO
+// UI 정렬: 최신순(createdAt DESC), 오래된순(createdAt ASC), 가나다순(title ASC)
+// thumbnail: 첫 번째 슬라이드 imageUrl 사용
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class StoryListResponse {
+public class StoryLibraryCardResponse {
 
     private Long storyId;
     private String title;
-    private String thumbnail;           // 첫 번째 슬라이드 imageUrl (신규)
-    private String childName;
-    private String primaryLanguage;     // 신규
-    private String secondaryLanguage;   // 신규
+    private String thumbnail;           // 첫 번째 슬라이드 imageUrl
+    private String primaryLanguage;
+    private String secondaryLanguage;
     private Boolean isPublic;
-    private LocalDateTime createdAt;
+    private LocalDateTime createdAt;    // Story.createdAt 기준 (UI 날짜 표시용)
     private Integer slideCount;
 
-    public static StoryListResponse from(Story story) {
+    public static StoryLibraryCardResponse from(Story story) {
+        // 첫 번째 슬라이드 imageUrl을 thumbnail로 사용
         String thumbnail = story.getSlides().isEmpty()
                 ? null
                 : story.getSlides().get(0).getImageUrl();
 
-        return StoryListResponse.builder()
+        return StoryLibraryCardResponse.builder()
                 .storyId(story.getStoryId())
                 .title(story.getTitle())
                 .thumbnail(thumbnail)
-                .childName(story.getChildName())
                 .primaryLanguage(story.getPrimaryLanguage())
                 .secondaryLanguage(story.getSecondaryLanguage())
                 .isPublic(story.getIsPublic())

--- a/src/main/java/com/moretale/domain/story/entity/Story.java
+++ b/src/main/java/com/moretale/domain/story/entity/Story.java
@@ -9,6 +9,25 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 동화 엔티티
+ *
+ * ── 삭제 cascade 흐름 ────────────────────────────────────────────────
+ * storyRepository.delete(story) 호출 시:
+ *
+ * [JPA 레벨]
+ *   Story
+ *    └── Slide           (CascadeType.ALL + orphanRemoval)
+ *          └── StoryToken (CascadeType.ALL + orphanRemoval)
+ *
+ * [DB 레벨 - @OnDelete(CASCADE)]
+ *   Story 삭제 → VocabularyEntry 자동 삭제
+ *   Slide  삭제 → VocabularyEntry 자동 삭제 (slide_id FK)
+ *   StoryToken 삭제 → VocabularyEntry 자동 삭제 (token_id FK)
+ *
+ * 결과: Story 삭제 한 번으로 관련 모든 데이터 정리됨
+ * ─────────────────────────────────────────────────────────────────────
+ */
 @Entity
 @Table(name = "stories")
 @Getter
@@ -50,6 +69,11 @@ public class Story {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * 슬라이드 목록
+     * - CascadeType.ALL: Story 저장/삭제 시 Slide도 함께 저장/삭제
+     * - orphanRemoval: Story에서 제거된 Slide는 자동 삭제
+     */
     @OneToMany(mappedBy = "story", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("order ASC")
     @Builder.Default

--- a/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
@@ -2,6 +2,8 @@ package com.moretale.domain.story.repository;
 
 import com.moretale.domain.story.entity.Story;
 import com.moretale.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,16 +15,16 @@ import java.util.Optional;
 @Repository
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
-    // 특정 사용자가 만든 동화 목록 조회
+    // 특정 사용자가 만든 동화 목록 조회 (최신순 고정 - 내부 사용)
     List<Story> findByUserOrderByCreatedAtDesc(User user);
 
-    // 공개된 동화 목록 조회
+    // 공개된 동화 목록 조회 (최신순 고정)
     List<Story> findByIsPublicTrueOrderByCreatedAtDesc();
 
     // 특정 동화 ID와 사용자로 조회 (권한 체크용)
     Optional<Story> findByStoryIdAndUser(Long storyId, User user);
 
-    // sl.tokens에 대한 Fetch Join을 제거하여 MultipleBagFetchException을 방지
+    // 슬라이드 Fetch Join (상세 조회용 - MultipleBagFetchException 방지)
     @Query("""
         SELECT DISTINCT s FROM Story s
         LEFT JOIN FETCH s.slides sl
@@ -32,4 +34,41 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
 
     // 사용자별 동화 개수
     long countByUser(User user);
+
+    /**
+     * 도서관 목록 조회 - Pageable 정렬 파라미터 지원
+     * 프론트 정렬 UI 매핑:
+     *   최신순    → sort=createdAt,desc
+     *   오래된순  → sort=createdAt,asc
+     *   가나다순  → sort=title,asc
+     *
+     * 슬라이드를 LEFT JOIN FETCH로 함께 가져와 thumbnail 추출 가능
+     * COUNT 쿼리는 별도로 분리하여 성능 최적화
+     */
+    @Query(
+            value = """
+            SELECT DISTINCT s FROM Story s
+            LEFT JOIN FETCH s.slides sl
+            WHERE s.user.userId = :userId
+        """,
+            countQuery = """
+            SELECT COUNT(s) FROM Story s
+            WHERE s.user.userId = :userId
+        """
+    )
+    Page<Story> findByUserIdWithSlides(@Param("userId") Long userId, Pageable pageable);
+
+    // 도서관 목록 조회 - 슬라이드 없이 (경량 버전, 썸네일 불필요 시)
+    @Query("""
+        SELECT s FROM Story s
+        WHERE s.user.userId = :userId
+    """)
+    Page<Story> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    // 공개 동화 목록 조회 - Pageable 정렬 지원
+    @Query("""
+        SELECT s FROM Story s
+        WHERE s.isPublic = true
+    """)
+    Page<Story> findPublicStories(Pageable pageable);
 }

--- a/src/main/java/com/moretale/domain/story/service/LibraryService.java
+++ b/src/main/java/com/moretale/domain/story/service/LibraryService.java
@@ -1,0 +1,135 @@
+package com.moretale.domain.story.service;
+
+import com.moretale.domain.story.dto.StoryLibraryCardResponse;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.domain.vocabulary.repository.VocabularyEntryRepository; // 단어장 리포지토리 주입 [cite: 70]
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 도서관 전용 서비스
+ * - 도서관 = 사용자가 생성한 동화 자체를 관리하는 영역 [cite: 253]
+ * - 삭제 = 동화 자체 삭제 (숨김 아님) [cite: 253, 260]
+ * - 삭제 시 Story → Slide → StoryToken → VocabularyEntry 순으로 연쇄 삭제 로직 포함 [cite: 260, 361]
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LibraryService {
+
+    private final StoryRepository storyRepository;
+    private final UserRepository userRepository;
+    private final VocabularyEntryRepository vocabularyEntryRepository; // 명시적 삭제를 위해 주입 [cite: 70, 254]
+
+    /**
+     * 도서관 목록 조회 (페이징 + 정렬)
+     *
+     * 프론트 정렬 파라미터 매핑: [cite: 254, 319]
+     * 최신순   → GET /api/library?sort=createdAt,desc
+     * 오래된순 → GET /api/library?sort=createdAt,asc
+     * 가나다순 → GET /api/library?sort=title,asc
+     *
+     * @param email    인증된 사용자 이메일
+     * @param pageable Spring Pageable (sort 파라미터 포함)
+     * @return 도서관 카드 Page
+     */
+    public Page<StoryLibraryCardResponse> getLibrary(String email, Pageable pageable) {
+        User user = getUserByEmail(email);
+
+        // 정렬 필드 화이트리스트 검증 (허용: createdAt, title) [cite: 256, 382]
+        Pageable safePageable = buildSafePageable(pageable);
+
+        Page<Story> stories = storyRepository.findByUserIdWithSlides(
+                user.getUserId(), safePageable
+        );
+
+        log.info("도서관 조회 - userId={}, page={}, sort={}, totalElements={}",
+                user.getUserId(),
+                pageable.getPageNumber(),
+                pageable.getSort(),
+                stories.getTotalElements());
+
+        return stories.map(StoryLibraryCardResponse::from);
+    }
+
+    /**
+     * 도서관에서 동화 삭제
+     * - Story 삭제 시 외래 키 제약 조건(VocabularyEntry 참조)을 해결하기 위해 자식 데이터를 먼저 삭제합니다. [cite: 386, 390]
+     *
+     * @param email   인증된 사용자 이메일
+     * @param storyId 삭제할 동화 ID
+     */
+    @Transactional
+    public void deleteFromLibrary(String email, Long storyId) {
+        User user = getUserByEmail(email);
+
+        Story story = storyRepository.findByStoryIdAndUser(storyId, user)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
+
+        // 1. 외래 키 제약 조건 위반 방지를 위해 관련 단어장 데이터를 명시적으로 먼저 삭제 [cite: 76, 240, 386]
+        // DB의 @OnDelete(CASCADE)가 설정되어 있더라도 JPA의 삭제 순서 최적화 과정에서 에러가 발생할 수 있으므로 안전하게 처리합니다.
+        vocabularyEntryRepository.deleteAllByStory(story);
+
+        // 2. 이후 동화 삭제 (JPA Cascade에 의해 Slide, StoryToken이 함께 삭제됨) [cite: 29, 262, 361]
+        storyRepository.delete(story);
+
+        log.info("도서관 동화 및 관련 단어장 데이터 완전 삭제 완료 - userId={}, storyId={}, title={}",
+                user.getUserId(), storyId, story.getTitle());
+    }
+
+    /**
+     * 정렬 필드 화이트리스트 검증 [cite: 264]
+     * - 허용 필드: createdAt, title [cite: 271, 382]
+     * - 허용되지 않은 필드가 오면 기본값(createdAt DESC)으로 대체하여 SQL Injection 방지 [cite: 268, 382]
+     */
+    private Pageable buildSafePageable(Pageable pageable) {
+        Sort sort = pageable.getSort();
+
+        // Sort가 없거나 비어있으면 기본값 적용 [cite: 265]
+        if (sort.isUnsorted()) {
+            return PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    Sort.by(Sort.Direction.DESC, "createdAt")
+            );
+        }
+
+        // 허용 필드 외 정렬 필드 제거 후 재구성 [cite: 266, 267]
+        Sort safeSort = Sort.by(
+                sort.stream()
+                        .filter(order -> isAllowedSortField(order.getProperty()))
+                        .map(order -> order.isAscending()
+                                ? Sort.Order.asc(order.getProperty())
+                                : Sort.Order.desc(order.getProperty()))
+                        .toList()
+        );
+
+        // 모든 정렬 필드가 거부된 경우 기본값 사용 [cite: 268, 269]
+        if (safeSort.isUnsorted()) {
+            safeSort = Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), safeSort);
+    }
+
+    private boolean isAllowedSortField(String field) {
+        return "createdAt".equals(field) || "title".equals(field);
+    }
+
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
+++ b/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
@@ -2,13 +2,18 @@ package com.moretale.domain.vocabulary.controller;
 
 import com.moretale.domain.vocabulary.dto.request.VocabularyCreateRequest;
 import com.moretale.domain.vocabulary.dto.request.VocabularyPatchRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularySearchCondition;
 import com.moretale.domain.vocabulary.dto.response.VocabularyResponse;
 import com.moretale.domain.vocabulary.dto.response.VocabularyStoryResponse;
 import com.moretale.domain.vocabulary.service.VocabularyService;
 import com.moretale.global.common.ApiResponse;
 import com.moretale.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +24,26 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * 단어장 API Controller
+ *
+ * ┌──────────────────────────────────────────────────────────────────────┐
+ * │  API 명세 (프론트 정렬 UI 연동)                                        │
+ * ├──────────────┬─────────────────────────────────────────────────────── │
+ * │  정렬 UI     │  요청 파라미터                                          │
+ * ├──────────────┼───────────────────────────────────────────────────────┤
+ * │  최신순      │  GET /api/vocabulary?sort=createdAt,desc               │
+ * │  오래된순    │  GET /api/vocabulary?sort=createdAt,asc                │
+ * │  가나다순    │  GET /api/vocabulary?sort=word,asc                     │
+ * ├──────────────┼───────────────────────────────────────────────────────┤
+ * │  즐겨찾기    │  GET /api/vocabulary?favorite=true                     │
+ * │  키워드검색  │  GET /api/vocabulary?keyword=사자                      │
+ * │  동화필터    │  GET /api/vocabulary?storyId=1                         │
+ * │  조합        │  GET /api/vocabulary?storyId=1&favorite=true&sort=word,asc │
+ * └──────────────┴───────────────────────────────────────────────────────┘
+ */
+@Tag(name = "Vocabulary", description = "단어장 API")
+@Slf4j
 @RestController
 @RequestMapping("/api/vocabulary")
 @RequiredArgsConstructor
@@ -30,6 +55,7 @@ public class VocabularyController {
      * POST /api/vocabulary
      * 단어 저장
      */
+    @Operation(summary = "단어 저장", description = "하이라이트 단어를 단어장에 저장합니다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<VocabularyResponse> save(
@@ -42,19 +68,65 @@ public class VocabularyController {
 
     /**
      * GET /api/vocabulary
-     * 내 전체 단어장 조회 (페이징)
-     * - storyId 쿼리 파라미터가 있으면 특정 동화 기준 조회
+     * 단어장 통합 조회 (필터 + 정렬 + 페이징)
+     *
+     * Query Parameters:
+     *   - storyId  : 특정 동화 필터 (없으면 전체)
+     *   - favorite : 즐겨찾기 필터 (true만 가능, 없으면 전체)
+     *   - keyword  : 단어/번역어 검색
+     *   - sort     : createdAt,desc | createdAt,asc | word,asc
+     *   - page     : 페이지 번호 (0부터 시작)
+     *   - size     : 페이지 크기 (기본 20)
      */
+    @Operation(
+            summary = "단어장 조회",
+            description = """
+                    단어장을 조회합니다. 필터와 정렬을 조합할 수 있습니다.
+                    
+                    **정렬 파라미터 (sort)**
+                    - `sort=createdAt,desc` : 최신순 (기본값)
+                    - `sort=createdAt,asc`  : 오래된순
+                    - `sort=word,asc`       : 가나다순
+                    
+                    **필터 파라미터**
+                    - `storyId=1`       : 특정 동화 단어만
+                    - `favorite=true`   : 즐겨찾기 단어만
+                    - `keyword=사자`    : 단어/번역어 검색
+                    
+                    **조합 예시**
+                    - `?storyId=1&sort=word,asc`
+                    - `?favorite=true&sort=createdAt,desc`
+                    - `?storyId=1&favorite=true&keyword=사자&sort=word,asc`
+                    """
+    )
     @GetMapping
     public ApiResponse<Page<VocabularyResponse>> getVocabulary(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestParam(name = "storyId", required = false) Long storyId, // name 명시로 에러 해결
+            @Parameter(description = "동화 ID 필터")
+            @RequestParam(name = "storyId", required = false) Long storyId,
+            @Parameter(description = "즐겨찾기 필터 (true이면 즐겨찾기만)")
+            @RequestParam(name = "favorite", required = false) Boolean favorite,
+            @Parameter(description = "단어/번역어 검색 키워드")
+            @RequestParam(name = "keyword", required = false) String keyword,
+            @Parameter(description = "페이징 및 정렬")
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Page<VocabularyResponse> result = (storyId != null)
-                ? vocabularyService.getByStory(principal.getUserId(), storyId, pageable)
-                : vocabularyService.getAll(principal.getUserId(), pageable);
+        log.info("단어장 조회 - userId={}, storyId={}, favorite={}, keyword={}, sort={}",
+                principal.getUserId(), storyId, favorite, keyword, pageable.getSort());
+
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        condition.setStoryId(storyId);
+        condition.setFavorite(favorite);
+        condition.setKeyword(keyword);
+
+        // 필터가 하나도 없으면 기존 단순 조회 사용 (성능 최적화)
+        Page<VocabularyResponse> result;
+        if (storyId == null && favorite == null && keyword == null) {
+            result = vocabularyService.getAll(principal.getUserId(), pageable);
+        } else {
+            result = vocabularyService.getWithFilters(principal.getUserId(), condition, pageable);
+        }
 
         return ApiResponse.success(result);
     }
@@ -63,6 +135,10 @@ public class VocabularyController {
      * GET /api/vocabulary/stories
      * 단어가 저장된 동화 목록 조회
      */
+    @Operation(
+            summary = "단어가 저장된 동화 목록 조회",
+            description = "단어장에 단어가 저장된 동화 목록과 각 동화별 단어 수를 반환합니다."
+    )
     @GetMapping("/stories")
     public ApiResponse<List<VocabularyStoryResponse>> getStoriesWithVocabulary(
             @AuthenticationPrincipal UserPrincipal principal
@@ -76,10 +152,14 @@ public class VocabularyController {
      * PATCH /api/vocabulary/{vocabularyId}
      * 단어장 항목 수정 (즐겨찾기 / 학습상태 / 메모)
      */
+    @Operation(
+            summary = "단어장 항목 수정",
+            description = "즐겨찾기, 학습상태, 메모를 수정합니다. null인 필드는 변경되지 않습니다."
+    )
     @PatchMapping("/{vocabularyId}")
     public ApiResponse<VocabularyResponse> patch(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable(name = "vocabularyId") Long vocabularyId, // name 명시
+            @PathVariable(name = "vocabularyId") Long vocabularyId,
             @RequestBody VocabularyPatchRequest request
     ) {
         VocabularyResponse response =
@@ -91,11 +171,12 @@ public class VocabularyController {
      * DELETE /api/vocabulary/{vocabularyId}
      * 단어 삭제
      */
+    @Operation(summary = "단어 삭제", description = "단어장에서 단어를 삭제합니다.")
     @DeleteMapping("/{vocabularyId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable(name = "vocabularyId") Long vocabularyId // name 명시
+            @PathVariable(name = "vocabularyId") Long vocabularyId
     ) {
         vocabularyService.delete(principal.getUserId(), vocabularyId);
     }

--- a/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularySearchCondition.java
+++ b/src/main/java/com/moretale/domain/vocabulary/dto/request/VocabularySearchCondition.java
@@ -1,0 +1,21 @@
+package com.moretale.domain.vocabulary.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 단어장 조회 필터 조건
+ * - favorite=true : 즐겨찾기 단어만 조회
+ * - keyword       : 단어(word) 또는 번역어(translation) 포함 검색
+ * - storyId       : 특정 동화 기준 필터
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class VocabularySearchCondition {
+
+    private Long storyId;           // null이면 전체
+    private Boolean favorite;       // null이면 전체, true이면 즐겨찾기만
+    private String keyword;         // null 또는 blank이면 검색 안 함
+}

--- a/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
+++ b/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
@@ -41,4 +41,76 @@ public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry
 
     // Story 삭제 시 연관된 단어장 전체 삭제용
     void deleteAllByStory(Story story);
+
+    /**
+     * 통합 필터 조회 (즐겨찾기 + 키워드 + 동화 필터 조합)
+     * 프론트 정렬 UI 매핑:
+     *   최신순    → sort=createdAt,desc
+     *   오래된순  → sort=createdAt,asc
+     *   가나다순  → sort=word,asc
+     *
+     * @param userId    사용자 ID (필수)
+     * @param storyId   동화 ID 필터 (null이면 전체)
+     * @param favorite  즐겨찾기 필터 (null이면 전체, true이면 즐겨찾기만)
+     * @param keyword   단어/번역어 검색 (null 또는 blank이면 전체)
+     * @param pageable  페이징 + 정렬
+     */
+    @Query("""
+        SELECT v FROM VocabularyEntry v
+        WHERE v.user.userId = :userId
+          AND (:storyId IS NULL OR v.story.storyId = :storyId)
+          AND (:favorite IS NULL OR v.isFavorite = :favorite)
+          AND (
+                :keyword IS NULL
+                OR v.word LIKE CONCAT('%', :keyword, '%')
+                OR v.translation LIKE CONCAT('%', :keyword, '%')
+              )
+    """)
+    Page<VocabularyEntry> findWithFilters(
+            @Param("userId") Long userId,
+            @Param("storyId") Long storyId,
+            @Param("favorite") Boolean favorite,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    // 즐겨찾기 단어 전체 조회 (페이징)
+    Page<VocabularyEntry> findByUser_UserIdAndIsFavoriteTrue(Long userId, Pageable pageable);
+
+    // 특정 동화 + 즐겨찾기 조회 (페이징)
+    Page<VocabularyEntry> findByUser_UserIdAndStory_StoryIdAndIsFavoriteTrue(
+            Long userId, Long storyId, Pageable pageable
+    );
+
+    // 단어 검색 (word 또는 translation 포함, 페이징)
+    @Query("""
+        SELECT v FROM VocabularyEntry v
+        WHERE v.user.userId = :userId
+          AND (
+                v.word LIKE CONCAT('%', :keyword, '%')
+                OR v.translation LIKE CONCAT('%', :keyword, '%')
+              )
+    """)
+    Page<VocabularyEntry> searchByKeyword(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    // 특정 동화에서 단어 검색 (페이징)
+    @Query("""
+        SELECT v FROM VocabularyEntry v
+        WHERE v.user.userId = :userId
+          AND v.story.storyId = :storyId
+          AND (
+                v.word LIKE CONCAT('%', :keyword, '%')
+                OR v.translation LIKE CONCAT('%', :keyword, '%')
+              )
+    """)
+    Page<VocabularyEntry> searchByKeywordAndStory(
+            @Param("userId") Long userId,
+            @Param("storyId") Long storyId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
+++ b/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
@@ -10,6 +10,7 @@ import com.moretale.domain.user.entity.User;
 import com.moretale.domain.user.repository.UserRepository;
 import com.moretale.domain.vocabulary.dto.request.VocabularyCreateRequest;
 import com.moretale.domain.vocabulary.dto.request.VocabularyPatchRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularySearchCondition;
 import com.moretale.domain.vocabulary.dto.response.VocabularyResponse;
 import com.moretale.domain.vocabulary.dto.response.VocabularyStoryResponse;
 import com.moretale.domain.vocabulary.entity.VocabularyEntry;
@@ -18,9 +19,12 @@ import com.moretale.domain.vocabulary.repository.VocabularyEntryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -36,8 +40,7 @@ public class VocabularyService {
     private final SlideRepository slideRepository;
     private final StoryTokenRepository storyTokenRepository;
 
-    // ── 단어 저장 ─────────────────────────────────────────────────────────────
-
+    // 단어 저장
     @Transactional
     public VocabularyResponse save(Long userId, VocabularyCreateRequest request) {
 
@@ -87,24 +90,65 @@ public class VocabularyService {
         return VocabularyResponse.from(saved);
     }
 
-    // ── 전체 단어장 조회 ──────────────────────────────────────────────────────
-
+    // 전체 단어장 조회
     public Page<VocabularyResponse> getAll(Long userId, Pageable pageable) {
+        Pageable safePageable = buildSafeVocabularyPageable(pageable);
         return vocabularyEntryRepository
-                .findByUser_UserId(userId, pageable)
+                .findByUser_UserId(userId, safePageable)
                 .map(VocabularyResponse::from);
     }
 
-    // ── 특정 동화 기준 단어장 조회 ────────────────────────────────────────────
-
+    // 특정 동화 기준 단어장 조회
     public Page<VocabularyResponse> getByStory(Long userId, Long storyId, Pageable pageable) {
+        Pageable safePageable = buildSafeVocabularyPageable(pageable);
         return vocabularyEntryRepository
-                .findByUser_UserIdAndStory_StoryId(userId, storyId, pageable)
+                .findByUser_UserIdAndStory_StoryId(userId, storyId, safePageable)
                 .map(VocabularyResponse::from);
     }
 
-    // ── 단어가 저장된 동화 목록 조회 ──────────────────────────────────────────
+    // 통합 필터 조회
+    /**
+     * 단어장 통합 필터 조회
+     * 프론트 정렬 파라미터 매핑:
+     *   최신순   → sort=createdAt,desc
+     *   오래된순 → sort=createdAt,asc
+     *   가나다순 → sort=word,asc
+     *
+     * @param userId    사용자 ID
+     * @param condition 필터 조건 (storyId, favorite, keyword)
+     * @param pageable  페이징 + 정렬
+     */
+    public Page<VocabularyResponse> getWithFilters(
+            Long userId,
+            VocabularySearchCondition condition,
+            Pageable pageable
+    ) {
+        Pageable safePageable = buildSafeVocabularyPageable(pageable);
 
+        // keyword 정규화: blank이면 null로 처리
+        String keyword = StringUtils.hasText(condition.getKeyword())
+                ? condition.getKeyword().trim()
+                : null;
+
+        log.info("단어장 필터 조회 - userId={}, storyId={}, favorite={}, keyword={}, sort={}",
+                userId,
+                condition.getStoryId(),
+                condition.getFavorite(),
+                keyword,
+                safePageable.getSort());
+
+        return vocabularyEntryRepository
+                .findWithFilters(
+                        userId,
+                        condition.getStoryId(),
+                        condition.getFavorite(),
+                        keyword,
+                        safePageable
+                )
+                .map(VocabularyResponse::from);
+    }
+
+    // 단어가 저장된 동화 목록 조회
     public List<VocabularyStoryResponse> getStoriesWithVocabulary(Long userId) {
         List<Story> stories = vocabularyEntryRepository.findDistinctStoriesByUserId(userId);
 
@@ -117,8 +161,7 @@ public class VocabularyService {
                 .toList();
     }
 
-    // ── 단어장 항목 수정 (즐겨찾기 / 학습상태 / 메모) ─────────────────────────
-
+    // 단어장 항목 수정 (기존 유지)
     @Transactional
     public VocabularyResponse patch(Long userId, Long vocabularyId, VocabularyPatchRequest request) {
         VocabularyEntry entry = findOwnedEntry(userId, vocabularyId);
@@ -137,8 +180,7 @@ public class VocabularyService {
         return VocabularyResponse.from(entry);
     }
 
-    // ── 단어 삭제 ─────────────────────────────────────────────────────────────
-
+    // 단어 삭제
     @Transactional
     public void delete(Long userId, Long vocabularyId) {
         VocabularyEntry entry = findOwnedEntry(userId, vocabularyId);
@@ -146,7 +188,7 @@ public class VocabularyService {
         log.info("단어장 삭제 완료 - userId={}, vocabularyId={}", userId, vocabularyId);
     }
 
-    // ── 내부 공통 메서드 ──────────────────────────────────────────────────────
+    // 내부 공통 메서드
 
     // 소유권 확인 후 엔티티 반환 (없으면 404, 권한 없으면 403)
     private VocabularyEntry findOwnedEntry(Long userId, Long vocabularyId) {
@@ -158,5 +200,41 @@ public class VocabularyService {
         return vocabularyEntryRepository
                 .findByVocabularyIdAndUser_UserId(vocabularyId, userId)
                 .orElseThrow(VocabularyAccessDeniedException::new);
+    }
+
+    /**
+     * 단어장 정렬 필드 화이트리스트 검증
+     * - 허용 필드: createdAt, word
+     * - 허용되지 않은 필드는 기본값(createdAt DESC)으로 대체
+     */
+    private Pageable buildSafeVocabularyPageable(Pageable pageable) {
+        Sort sort = pageable.getSort();
+
+        if (sort.isUnsorted()) {
+            return PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    Sort.by(Sort.Direction.DESC, "createdAt")
+            );
+        }
+
+        Sort safeSort = Sort.by(
+                sort.stream()
+                        .filter(order -> isAllowedVocabSortField(order.getProperty()))
+                        .map(order -> order.isAscending()
+                                ? Sort.Order.asc(order.getProperty())
+                                : Sort.Order.desc(order.getProperty()))
+                        .toList()
+        );
+
+        if (safeSort.isUnsorted()) {
+            safeSort = Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), safeSort);
+    }
+
+    private boolean isAllowedVocabSortField(String field) {
+        return "createdAt".equals(field) || "word".equals(field);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #22

## ✨ 작업 내용 요약
> 도서관(Library) 및 단어장(Vocabulary) 기능을 실제 UI 흐름에 맞게 완성하고, 정렬, 필터, 삭제 정책을 포함한 API 명세를 확정

[도서관(Library) 기능 구현]
- 도서관 API 설계 및 구현
  - `GET /api/library` : 도서관 목록 조회 (페이징)
  - 최신순 / 오래된순 / 가나다순 정렬 지원
  - `DELETE /api/library/{storyId}` : 동화 삭제
  - `Story` + `Slide` + `StoryToken` + `VocabularyEntry` 전체 삭제
- 정렬 기준 정의
  - `createdAt` 기준 정렬 (최신순 / 오래된순)
  - `title` 기준 정렬 (가나다순)
  - sort 파라미터 형식 통일 (`sort=createdAt,desc`)
- 도서관 카드 응답 구조 설계
  - `StoryLibraryCardResponse` DTO 추가
  - `thumbnail` (첫 번째 슬라이드 `imageUrl`) 포함
  - `primaryLanguage` / `secondaryLanguage` 포함
  - `createdAt`, `slideCount` 포함
- 도서관 삭제 정책 구현
  - '숨김'이 아닌 동화 자체 삭제로 정의
  - `VocabularyEntry` 선삭제 후 `Story` 삭제하도록 처리
  - 연쇄 삭제 흐름 검증 완료

[동화 목록 응답 구조 개선]
- `StoryListResponse` 확장
  - `thumbnail` 추가
  - `primaryLanguage` / `secondaryLanguage` 추가
- 도서관 UI와 응답 구조 일관성 맞춤

[단어장(Vocabulary) 조회 기능 확장]
- 단어장 조회 API 개선
  - `GET /api/vocabulary` : 통합 조회 (페이징 + 정렬 + 필터)
- 정렬 기능
  - 최신순 (`createdAt DESC`)
  - 오래된순 (`createdAt ASC`)
  - 가나다순 `(word ASC`)
- 필터 기능
  - `storyId` : 특정 동화 기준 조회
  - `favorite=true` : 즐겨찾기 단어 조회
  - `keyword` : 단어/번역어 검색
- 조합 조회 지원
  - `storyId` + `favorite` + `keyword` + `sort` 조합 가능

[단어장 검색 및 필터 로직 구현]
- `VocabularySearchCondition` DTO 추가
- `keyword` 검색 (word / translation LIKE 검색)
- JPQL LIKE → CONCAT 방식으로 안정화
- keyword blank → null 처리하여 전체 조회 fallback

[단어장 Repository 확장]
- 통합 필터 조회 쿼리 (`findWithFilters`) 추가
- 즐겨찾기 조회 쿼리 추가
- 키워드 검색 쿼리 추가
- 동화 기준 검색 쿼리 추가

[정렬 및 API 설계 정리]
- Pageable + query param 기반 구조 유지
- 정렬 필드 UI와 1:1 매핑
- 프론트 정렬 UI와 API 완전 일치

## 🗒️ 참고 사항
- 도서관은 '내 목록'이 아니라 동화 자체 관리 영역으로 설계
- 동화 삭제 시 관련 데이터 전체 제거 (orphan 없음)
- 단어장은 '전체 조회 + 동화 기준 조회' 구조로 설계
- keyword가 빈 문자열일 경우 null 처리되어 전체 조회로 동작
- 도서관 카드의 생성일자는 `Story.createdAt` 기준 사용
- 단어장 번호(1,2,3…)는 UI 요소이므로 백엔드에서 제공하지 않음
- 조회 API는 확장 가능하도록 pageable 구조 유지