### PR TITLE
Feat/12-vocabulary-favorite-sort

### DIFF
--- a/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
+++ b/src/main/java/com/moretale/domain/vocabulary/controller/VocabularyController.java
@@ -27,20 +27,19 @@ import java.util.List;
 /**
  * 단어장 API Controller
  *
- * ┌──────────────────────────────────────────────────────────────────────┐
- * │  API 명세 (프론트 정렬 UI 연동)                                        │
- * ├──────────────┬─────────────────────────────────────────────────────── │
- * │  정렬 UI     │  요청 파라미터                                          │
- * ├──────────────┼───────────────────────────────────────────────────────┤
- * │  최신순      │  GET /api/vocabulary?sort=createdAt,desc               │
- * │  오래된순    │  GET /api/vocabulary?sort=createdAt,asc                │
- * │  가나다순    │  GET /api/vocabulary?sort=word,asc                     │
- * ├──────────────┼───────────────────────────────────────────────────────┤
- * │  즐겨찾기    │  GET /api/vocabulary?favorite=true                     │
- * │  키워드검색  │  GET /api/vocabulary?keyword=사자                      │
- * │  동화필터    │  GET /api/vocabulary?storyId=1                         │
- * │  조합        │  GET /api/vocabulary?storyId=1&favorite=true&sort=word,asc │
- * └──────────────┴───────────────────────────────────────────────────────┘
+ * ┌──────────────────────────────────────────────────────────────────────────────┐
+ * │  API 명세 (프론트 정렬 UI 연동)                                               │
+ * ├──────────────┬───────────────────────────────────────────────────────────────┤
+ * │  정렬 UI     │  요청 파라미터              │  실제 적용 ORDER BY              │
+ * ├──────────────┼─────────────────────────────┼──────────────────────────────────┤
+ * │  최신순(기본)│  sort=createdAt,desc        │  isFavorite DESC, createdAt DESC │
+ * │  오래된순    │  sort=createdAt,asc         │  isFavorite DESC, createdAt ASC  │
+ * │  가나다순    │  sort=word,asc              │  isFavorite DESC, word ASC       │
+ * ├──────────────┼─────────────────────────────┼──────────────────────────────────┤
+ * │  즐겨찾기    │  favorite=true              │  (isFavorite 필터이므로 선행 정렬 생략) │
+ * │  키워드검색  │  keyword=사자               │                                  │
+ * │  동화필터    │  storyId=1                  │                                  │
+ * └──────────────┴─────────────────────────────┴──────────────────────────────────┘
  */
 @Tag(name = "Vocabulary", description = "단어장 API")
 @Slf4j
@@ -77,26 +76,29 @@ public class VocabularyController {
      *   - sort     : createdAt,desc | createdAt,asc | word,asc
      *   - page     : 페이지 번호 (0부터 시작)
      *   - size     : 페이지 크기 (기본 20)
+     *
+     * ※ 정렬 정책: 즐겨찾기(isFavorite DESC) 우선 → 사용자 선택 정렬 순
+     *   단, favorite=true 필터 사용 시에는 isFavorite 선행 정렬 생략
      */
     @Operation(
             summary = "단어장 조회",
             description = """
-                    단어장을 조회합니다. 필터와 정렬을 조합할 수 있습니다.
+                    단어장을 조회합니다. 즐겨찾기 단어가 항상 상단에 표시됩니다.
                     
                     **정렬 파라미터 (sort)**
-                    - `sort=createdAt,desc` : 최신순 (기본값)
-                    - `sort=createdAt,asc`  : 오래된순
-                    - `sort=word,asc`       : 가나다순
+                    - `sort=createdAt,desc` : 즐겨찾기 우선 → 최신순 (기본값)
+                    - `sort=createdAt,asc`  : 즐겨찾기 우선 → 오래된순
+                    - `sort=word,asc`       : 즐겨찾기 우선 → 가나다순
                     
                     **필터 파라미터**
                     - `storyId=1`       : 특정 동화 단어만
-                    - `favorite=true`   : 즐겨찾기 단어만
+                    - `favorite=true`   : 즐겨찾기 단어만 (이 경우 isFavorite 선행 정렬 생략)
                     - `keyword=사자`    : 단어/번역어 검색
                     
                     **조합 예시**
                     - `?storyId=1&sort=word,asc`
                     - `?favorite=true&sort=createdAt,desc`
-                    - `?storyId=1&favorite=true&keyword=사자&sort=word,asc`
+                    - `?storyId=1&keyword=사자&sort=word,asc`
                     """
     )
     @GetMapping
@@ -108,7 +110,8 @@ public class VocabularyController {
             @RequestParam(name = "favorite", required = false) Boolean favorite,
             @Parameter(description = "단어/번역어 검색 키워드")
             @RequestParam(name = "keyword", required = false) String keyword,
-            @Parameter(description = "페이징 및 정렬")
+            @Parameter(description = "페이징 및 정렬 (기본: 즐겨찾기 우선 → 최신순)")
+            // ✅ 변경: 기본 정렬을 createdAt DESC로 명시 (isFavorite DESC는 Service에서 자동 삽입)
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
@@ -120,13 +123,16 @@ public class VocabularyController {
         condition.setFavorite(favorite);
         condition.setKeyword(keyword);
 
-        // 필터가 하나도 없으면 기존 단순 조회 사용 (성능 최적화)
-        Page<VocabularyResponse> result;
-        if (storyId == null && favorite == null && keyword == null) {
-            result = vocabularyService.getAll(principal.getUserId(), pageable);
-        } else {
-            result = vocabularyService.getWithFilters(principal.getUserId(), condition, pageable);
-        }
+        /*
+         * 필터 유무와 관계없이 getWithFilters()로 통합
+         * → isFavorite 우선 정렬 정책을 필터 없는 경우에도 일관되게 적용하기 위해
+         *   필터 없음(전체 조회) 분기도 getWithFilters()로 처리한다.
+         *
+         * 참고: getAll()은 Service에서 내부적으로 유지되며
+         *       다른 곳(예: 배치, 관리자 API)에서 재사용 가능
+         */
+        Page<VocabularyResponse> result =
+                vocabularyService.getWithFilters(principal.getUserId(), condition, pageable);
 
         return ApiResponse.success(result);
     }

--- a/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
+++ b/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry, Long> {
 
-    // 내 전체 단어장 조회 (페이징)
+    // 내 전체 단어장 조회 (페이징) - Pageable에 isFavorite DESC가 포함되어 들어옴
     Page<VocabularyEntry> findByUser_UserId(Long userId, Pageable pageable);
 
     // 특정 동화 기준 단어장 조회 (페이징)
@@ -44,33 +44,35 @@ public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry
 
     /**
      * 통합 필터 조회 (즐겨찾기 + 키워드 + 동화 필터 조합)
-     * 프론트 정렬 UI 매핑:
-     *   최신순    → sort=createdAt,desc
-     *   오래된순  → sort=createdAt,asc
-     *   가나다순  → sort=word,asc
      *
-     * @param userId    사용자 ID (필수)
-     * @param storyId   동화 ID 필터 (null이면 전체)
-     * @param favorite  즐겨찾기 필터 (null이면 전체, true이면 즐겨찾기만)
-     * @param keyword   단어/번역어 검색 (null 또는 blank이면 전체)
-     * @param pageable  페이징 + 정렬
+     * ─ keyword 처리 방식 변경 ────────────────────────────────────────────────
+     *   기존: LIKE CONCAT('%', :keyword, '%') — PostgreSQL + Hibernate 6 조합에서
+     *         keyword=null 시 파라미터 타입을 bytea로 추론하여 타입 오류 발생
+     *
+     *   변경: :keywordPattern 으로 받고, Service에서 null → null, 값 → "%값%" 변환
+     *         IS NULL 분기와 LIKE 절의 파라미터를 분리하여 타입 충돌 방지
+     * ─────────────────────────────────────────────────────────────────────────
+     *
+     * @param userId         사용자 ID (필수)
+     * @param storyId        동화 ID 필터 (null이면 전체)
+     * @param favorite       즐겨찾기 필터 (null이면 전체, true이면 즐겨찾기만)
+     * @param keywordPattern LIKE 패턴 문자열 (null이면 전체, 값이면 "%keyword%")
+     * @param pageable       페이징 + 정렬 (isFavorite DESC가 선행 적용된 Pageable)
      */
     @Query("""
-        SELECT v FROM VocabularyEntry v
-        WHERE v.user.userId = :userId
-          AND (:storyId IS NULL OR v.story.storyId = :storyId)
-          AND (:favorite IS NULL OR v.isFavorite = :favorite)
-          AND (
-                :keyword IS NULL
-                OR v.word LIKE CONCAT('%', :keyword, '%')
-                OR v.translation LIKE CONCAT('%', :keyword, '%')
-              )
-    """)
+    SELECT v FROM VocabularyEntry v
+    WHERE v.user.userId = :userId
+      AND (:storyId IS NULL OR v.story.storyId = :storyId)
+      AND (:favorite IS NULL OR v.isFavorite = :favorite)
+      AND (:keywordPattern IS NULL
+            OR v.word LIKE :keywordPattern
+            OR v.translation LIKE :keywordPattern)
+""")
     Page<VocabularyEntry> findWithFilters(
             @Param("userId") Long userId,
             @Param("storyId") Long storyId,
             @Param("favorite") Boolean favorite,
-            @Param("keyword") String keyword,
+            @Param("keywordPattern") String keywordPattern,
             Pageable pageable
     );
 

--- a/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
+++ b/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -92,6 +93,7 @@ public class VocabularyService {
 
     // 전체 단어장 조회
     public Page<VocabularyResponse> getAll(Long userId, Pageable pageable) {
+        // buildSafeVocabularyPageable 내부에서 isFavorite DESC가 맨 앞에 삽입됨
         Pageable safePageable = buildSafeVocabularyPageable(pageable);
         return vocabularyEntryRepository
                 .findByUser_UserId(userId, safePageable)
@@ -100,19 +102,28 @@ public class VocabularyService {
 
     // 특정 동화 기준 단어장 조회
     public Page<VocabularyResponse> getByStory(Long userId, Long storyId, Pageable pageable) {
+        // buildSafeVocabularyPageable 내부에서 isFavorite DESC가 맨 앞에 삽입됨
         Pageable safePageable = buildSafeVocabularyPageable(pageable);
         return vocabularyEntryRepository
                 .findByUser_UserIdAndStory_StoryId(userId, storyId, safePageable)
                 .map(VocabularyResponse::from);
     }
 
-    // 통합 필터 조회
     /**
      * 단어장 통합 필터 조회
-     * 프론트 정렬 파라미터 매핑:
-     *   최신순   → sort=createdAt,desc
-     *   오래된순 → sort=createdAt,asc
-     *   가나다순 → sort=word,asc
+     *
+     * ─ 정렬 정책 (isFavorite 우선) ──────────────────────────────────────────
+     *   buildSafeVocabularyPageable() 에서 isFavorite DESC 를 맨 앞에 고정하고
+     *   사용자가 선택한 정렬(createdAt / word)을 그 뒤에 붙인다.
+     *
+     *   결과 ORDER BY 예시:
+     *     최신순   →  isFavorite DESC, createdAt DESC
+     *     오래된순 →  isFavorite DESC, createdAt ASC
+     *     가나다순 →  isFavorite DESC, word ASC
+     * ─────────────────────────────────────────────────────────────────────────
+     *
+     * 단, favorite=true 필터가 걸린 경우에는 결과가 모두 즐겨찾기이므로
+     * isFavorite DESC 선행 정렬이 의미 없어 생략한다. (불필요한 ORDER BY 제거)
      *
      * @param userId    사용자 ID
      * @param condition 필터 조건 (storyId, favorite, keyword)
@@ -123,18 +134,20 @@ public class VocabularyService {
             VocabularySearchCondition condition,
             Pageable pageable
     ) {
-        Pageable safePageable = buildSafeVocabularyPageable(pageable);
-
-        // keyword 정규화: blank이면 null로 처리
-        String keyword = StringUtils.hasText(condition.getKeyword())
-                ? condition.getKeyword().trim()
+        // null이면 null 유지, 값이 있으면 "%keyword%" 패턴으로 변환
+        // Repository의 :keywordPattern 파라미터에 전달
+        String keywordPattern = StringUtils.hasText(condition.getKeyword())
+                ? "%" + condition.getKeyword().trim() + "%"
                 : null;
+
+        boolean skipFavoriteSort = Boolean.TRUE.equals(condition.getFavorite());
+        Pageable safePageable = buildSafeVocabularyPageable(pageable, skipFavoriteSort);
 
         log.info("단어장 필터 조회 - userId={}, storyId={}, favorite={}, keyword={}, sort={}",
                 userId,
                 condition.getStoryId(),
                 condition.getFavorite(),
-                keyword,
+                keywordPattern,
                 safePageable.getSort());
 
         return vocabularyEntryRepository
@@ -142,7 +155,7 @@ public class VocabularyService {
                         userId,
                         condition.getStoryId(),
                         condition.getFavorite(),
-                        keyword,
+                        keywordPattern,
                         safePageable
                 )
                 .map(VocabularyResponse::from);
@@ -161,7 +174,7 @@ public class VocabularyService {
                 .toList();
     }
 
-    // 단어장 항목 수정 (기존 유지)
+    // 단어장 항목 수정 (즐겨찾기 / 학습상태 / 메모)
     @Transactional
     public VocabularyResponse patch(Long userId, Long vocabularyId, VocabularyPatchRequest request) {
         VocabularyEntry entry = findOwnedEntry(userId, vocabularyId);
@@ -188,52 +201,93 @@ public class VocabularyService {
         log.info("단어장 삭제 완료 - userId={}, vocabularyId={}", userId, vocabularyId);
     }
 
-    // 내부 공통 메서드
+    // ── 내부 공통 메서드 ────────────────────────────────────────────────────────
 
     // 소유권 확인 후 엔티티 반환 (없으면 404, 권한 없으면 403)
     private VocabularyEntry findOwnedEntry(Long userId, Long vocabularyId) {
-        // 먼저 존재 여부 확인
         if (!vocabularyEntryRepository.existsById(vocabularyId)) {
             throw new VocabularyNotFoundException(vocabularyId);
         }
-        // 소유권 확인
         return vocabularyEntryRepository
                 .findByVocabularyIdAndUser_UserId(vocabularyId, userId)
                 .orElseThrow(VocabularyAccessDeniedException::new);
     }
 
     /**
-     * 단어장 정렬 필드 화이트리스트 검증
-     * - 허용 필드: createdAt, word
-     * - 허용되지 않은 필드는 기본값(createdAt DESC)으로 대체
+     * 단어장 정렬 필드 화이트리스트 검증 + isFavorite DESC 선행 삽입
+     *
+     * ─ 정렬 규칙 ────────────────────────────────────────────────────────────
+     *   1. 허용 필드: isFavorite, createdAt, word  (그 외는 무시)
+     *   2. skipFavoriteSort = false 인 경우 (기본):
+     *        → isFavorite DESC 를 정렬 맨 앞에 고정
+     *        → 이후 사용자 요청 정렬(createdAt / word)을 추가
+     *        → 사용자 정렬이 없으면 createdAt DESC 를 기본값으로 사용
+     *      결과 예:
+     *        sort=createdAt,desc  →  [isFavorite DESC, createdAt DESC]  (기본)
+     *        sort=createdAt,asc   →  [isFavorite DESC, createdAt ASC]
+     *        sort=word,asc        →  [isFavorite DESC, word ASC]
+     *        sort 없음            →  [isFavorite DESC, createdAt DESC]
+     *
+     *   3. skipFavoriteSort = true 인 경우 (favorite=true 필터 사용 시):
+     *        → isFavorite DESC 삽입 생략 (결과가 이미 전부 즐겨찾기)
+     *        → 사용자 요청 정렬만 적용
+     * ─────────────────────────────────────────────────────────────────────────
+     *
+     * @param pageable          원본 Pageable (Controller에서 전달)
+     * @param skipFavoriteSort  true이면 isFavorite DESC 선행 삽입 생략
      */
-    private Pageable buildSafeVocabularyPageable(Pageable pageable) {
+    private Pageable buildSafeVocabularyPageable(Pageable pageable, boolean skipFavoriteSort) {
         Sort sort = pageable.getSort();
 
-        if (sort.isUnsorted()) {
-            return PageRequest.of(
-                    pageable.getPageNumber(),
-                    pageable.getPageSize(),
-                    Sort.by(Sort.Direction.DESC, "createdAt")
-            );
+        // 사용자 요청 정렬에서 허용 필드(createdAt, word)만 추출
+        // (isFavorite은 사용자가 직접 정렬 파라미터로 넘기는 필드가 아니므로 화이트리스트에서 제외)
+        List<Sort.Order> userOrders = new ArrayList<>();
+        if (sort.isSorted()) {
+            sort.stream()
+                    .filter(order -> isAllowedVocabSortField(order.getProperty()))
+                    .map(order -> order.isAscending()
+                            ? Sort.Order.asc(order.getProperty())
+                            : Sort.Order.desc(order.getProperty()))
+                    .forEach(userOrders::add);
         }
 
-        Sort safeSort = Sort.by(
-                sort.stream()
-                        .filter(order -> isAllowedVocabSortField(order.getProperty()))
-                        .map(order -> order.isAscending()
-                                ? Sort.Order.asc(order.getProperty())
-                                : Sort.Order.desc(order.getProperty()))
-                        .toList()
+        // 사용자 정렬이 비어있으면 기본값 createdAt DESC 사용
+        if (userOrders.isEmpty()) {
+            userOrders.add(Sort.Order.desc("createdAt"));
+        }
+
+        // 최종 정렬 조합
+        List<Sort.Order> finalOrders = new ArrayList<>();
+
+        if (!skipFavoriteSort) {
+            // isFavorite DESC 를 맨 앞에 고정
+            finalOrders.add(Sort.Order.desc("isFavorite"));
+        }
+
+        // 사용자 정렬을 그 뒤에 추가
+        finalOrders.addAll(userOrders);
+
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(finalOrders)
         );
-
-        if (safeSort.isUnsorted()) {
-            safeSort = Sort.by(Sort.Direction.DESC, "createdAt");
-        }
-
-        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), safeSort);
     }
 
+    /**
+     * skipFavoriteSort = false 로 고정하는 편의 오버로드
+     * (기존 getAll, getByStory 등에서 사용)
+     */
+    private Pageable buildSafeVocabularyPageable(Pageable pageable) {
+        return buildSafeVocabularyPageable(pageable, false);
+    }
+
+    /**
+     * 사용자가 sort 파라미터로 직접 지정할 수 있는 허용 필드
+     * - createdAt : 최신순 / 오래된순
+     * - word      : 가나다순
+     * (isFavorite은 Service 내부에서 자동 삽입하므로 사용자 입력 허용 안 함)
+     */
     private boolean isAllowedVocabSortField(String field) {
         return "createdAt".equals(field) || "word".equals(field);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #24

## ✨ 작업 내용 요약
- 단어장(`Vocabulary`) 조회 시 **즐겨찾기 우선 정렬 정책을 적용**
- PostgreSQL 환경에서 발생하던 `keyword` 검색 LIKE 타입 오류 수정
- 단어장 조회 시 정렬 기준을 다음과 같이 변경
  - 즐겨찾기(`isFavorite=true`) 단어를 항상 상단에 배치
  - 이후 사용자 선택 정렬 기준을 적용
  - `favorite=true` 필터 적용 시 결과가 모두 즐겨찾기이므로 `isFavorite DESC` 선행 정렬은 생략하도록 처리
  - `GET /api/vocabulary`                      → ORDER BY isFavorite DESC, createdAt DESC
  - `GET /api/vocabulary?sort=word,asc`        → ORDER BY isFavorite DESC, word ASC
  - `GET /api/vocabulary?sort=createdAt,asc`   → ORDER BY isFavorite DESC, createdAt ASC
  - `GET /api/vocabulary?favorite=true`        → ORDER BY createdAt DESC  (isFavorite 선행 생략)
  - `GET /api/vocabulary?storyId=(number)&keyword=(word)` → ORDER BY isFavorite DESC, createdAt DESC
- Controller에서 모든 조회를 `getWithFilters()`로 통합
- 필터 유무와 관계없이 동일한 정렬 정책 적용
- `isFavorite DESC`를 정렬 맨 앞에 자동 삽입하도록 개선
- 사용자 정렬(`createdAt`, `word`)은 그 뒤에 적용
- 허용되지 않은 정렬 필드는 필터링 (화이트리스트 적용)
- PostgreSQL + Hibernate 환경에서 발생하던 `character varying ~~ bytea` 오류 해결
  - `keyword` → `keywordPattern` 방식으로 변경
  - Service에서 `%keyword%` 형태로 변환 후 전달
  - Repository에서는 `LIKE :keywordPattern` 형태로 처리
- `findWithFilters` 쿼리 수정
  - `LIKE CONCAT('%', :keyword, '%')` → `LIKE :keywordPattern`
  - `keyword` null 처리 시 타입 충돌 방지

## 🗒️ 참고 사항
- 정렬 정책은 **즐겨찾기 우선 → 사용자 선택 정렬** 구조로 통일
- `keyword`가 null 또는 blank인 경우 전체 조회로 fallback
- 기존 LIKE CONCAT 방식은 PostgreSQL에서 타입 추론 문제를 유발할 수 있어 개선
- `favorite=true` 필터 사용 시 불필요한 정렬 제거로 쿼리 단순화
- 기존 API 구조(Pageable 기반)는 유지하면서 내부 로직만 개선