### PR TITLE
Feat/13-quiz-reward-system

### DIFF
--- a/src/main/java/com/moretale/domain/honeyjar/controller/HoneyJarController.java
+++ b/src/main/java/com/moretale/domain/honeyjar/controller/HoneyJarController.java
@@ -1,0 +1,85 @@
+package com.moretale.domain.honeyjar.controller;
+
+import com.moretale.domain.honeyjar.dto.HoneyJarHistoryResponse;
+import com.moretale.domain.honeyjar.dto.HoneyJarResponse;
+import com.moretale.domain.honeyjar.service.HoneyJarService;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.common.ApiResponse;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "HoneyJar", description = "꿀단지 보상 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/honey-jar")
+@RequiredArgsConstructor
+public class HoneyJarController {
+
+    private final HoneyJarService honeyJarService;
+    private final UserRepository userRepository;
+
+    // 꿀단지 현황 조회
+    // GET /api/honey-jar
+    @Operation(
+            summary = "꿀단지 현황 조회",
+            description = """
+                    현재 사용자의 꿀단지 보유 현황을 조회합니다.
+                    
+                    **응답 정보**
+                    - `count`: 현재 보유 꿀단지 수
+                    - `canGenerateFree`: 동화 무료 생성 가능 여부 (20개 이상)
+                    - `remainingForFree`: 무료 생성까지 남은 꿀단지 수
+                    """
+    )
+    @GetMapping
+    public ApiResponse<HoneyJarResponse> getHoneyJar(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        log.info("꿀단지 조회 요청 - email={}", userDetails.getUsername());
+
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        HoneyJarResponse response = honeyJarService.getHoneyJar(user);
+        return ApiResponse.success(response, "꿀단지 조회 성공");
+    }
+
+    // 꿀단지 이력 조회
+    // GET /api/honey-jar/history
+    @Operation(
+            summary = "꿀단지 이력 조회",
+            description = """
+                    현재 사용자의 꿀단지 획득/사용 이력을 최신순으로 조회합니다.
+                    
+                    **응답 정보**
+                    - `actionType`: 변동 유형
+                    - `amount`: 변동 수량 (획득: 양수, 사용: 음수)
+                    - `reason`: 변동 사유
+                    - `balanceAfter`: 변동 후 잔액
+                    - `storyId`: 관련 동화 ID
+                    - `createdAt`: 이력 생성 시각
+                    """
+    )
+    @GetMapping("/history")
+    public ApiResponse<List<HoneyJarHistoryResponse>> getHoneyJarHistory(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        log.info("꿀단지 이력 조회 요청 - email={}", userDetails.getUsername());
+
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<HoneyJarHistoryResponse> response = honeyJarService.getHoneyJarHistory(user);
+        return ApiResponse.success(response, "꿀단지 이력 조회 성공");
+    }
+}

--- a/src/main/java/com/moretale/domain/honeyjar/dto/HoneyJarHistoryResponse.java
+++ b/src/main/java/com/moretale/domain/honeyjar/dto/HoneyJarHistoryResponse.java
@@ -1,0 +1,32 @@
+package com.moretale.domain.honeyjar.dto;
+
+import com.moretale.domain.honeyjar.entity.HoneyJarHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class HoneyJarHistoryResponse {
+
+    private Long historyId;
+    private String actionType;
+    private Integer amount;
+    private String reason;
+    private Integer balanceAfter;
+    private Long storyId;
+    private LocalDateTime createdAt;
+
+    public static HoneyJarHistoryResponse from(HoneyJarHistory history) {
+        return HoneyJarHistoryResponse.builder()
+                .historyId(history.getHistoryId())
+                .actionType(history.getActionType().name())
+                .amount(history.getAmount())
+                .reason(history.getReason())
+                .balanceAfter(history.getBalanceAfter())
+                .storyId(history.getStoryId())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/honeyjar/dto/HoneyJarResponse.java
+++ b/src/main/java/com/moretale/domain/honeyjar/dto/HoneyJarResponse.java
@@ -1,0 +1,32 @@
+package com.moretale.domain.honeyjar.dto;
+
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import lombok.*;
+
+// 꿀단지 상태 응답 DTO
+// GET /api/honey-jar 응답
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HoneyJarResponse {
+
+    private Integer count;              // 현재 보유 꿀단지 수
+    private Integer totalEarned;        // 누적 획득 수
+    private Integer totalUsed;          // 누적 사용 수
+    private Boolean canGenerateFree;    // 무료 생성 가능 여부
+    private Integer remainingForFree;   // 무료 생성까지 남은 꿀단지 수
+
+    private static final int FREE_GENERATION_THRESHOLD = 20;
+
+    public static HoneyJarResponse from(HoneyJar honeyJar) {
+        int remaining = Math.max(0, FREE_GENERATION_THRESHOLD - honeyJar.getCount());
+        return HoneyJarResponse.builder()
+                .count(honeyJar.getCount())
+                .totalEarned(honeyJar.getTotalEarned())
+                .totalUsed(honeyJar.getTotalUsed())
+                .canGenerateFree(honeyJar.canGenerateFree())
+                .remainingForFree(remaining)
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJar.java
+++ b/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJar.java
@@ -1,0 +1,72 @@
+package com.moretale.domain.honeyjar.entity;
+
+import com.moretale.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 꿀단지 누적 자산
+ * - 사용자당 1개 레코드 (누적 관리)
+ * - 동화 완독 시 +1, 퀴즈 100점 시 +1 (동화 1권당 최대 2개)
+ * - 20개 달성 시 동화 1권 무료 생성에 자동 차감
+ */
+@Entity
+@Table(name = "honey_jars")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HoneyJar {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "honey_jar_id")
+    private Long honeyJarId;
+
+    // 사용자당 1개 레코드
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 현재 보유 꿀단지 수
+    @Column(name = "count", nullable = false)
+    @Builder.Default
+    private Integer count = 0;
+
+    // 누적 획득 꿀단지 수 (통계용)
+    @Column(name = "total_earned", nullable = false)
+    @Builder.Default
+    private Integer totalEarned = 0;
+
+    // 누적 사용 꿀단지 수 (통계용)
+    @Column(name = "total_used", nullable = false)
+    @Builder.Default
+    private Integer totalUsed = 0;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // 꿀단지 추가
+    public void add(int amount) {
+        this.count += amount;
+        this.totalEarned += amount;
+    }
+
+    // 꿀단지 차감 (20개 → 동화 1권 무료)
+    public boolean use(int amount) {
+        if (this.count < amount) return false;
+        this.count -= amount;
+        this.totalUsed += amount;
+        return true;
+    }
+
+    // 무료 생성 가능 여부 (20개 이상)
+    public boolean canGenerateFree() {
+        return this.count >= 20;
+    }
+}

--- a/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJarAction.java
+++ b/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJarAction.java
@@ -1,0 +1,14 @@
+package com.moretale.domain.honeyjar.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HoneyJarAction {
+    EARN_STORY_COMPLETE("동화 완독 보상"),    // 동화 완독 시 +1
+    EARN_QUIZ_PERFECT("퀴즈 100점 보상"),     // 퀴즈 100점 시 +1
+    USE_FREE_GENERATION("동화 무료 생성 사용"); // 동화 무료 생성 -20
+
+    private final String description;
+}

--- a/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJarHistory.java
+++ b/src/main/java/com/moretale/domain/honeyjar/entity/HoneyJarHistory.java
@@ -1,0 +1,57 @@
+package com.moretale.domain.honeyjar.entity;
+
+import com.moretale.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 꿀단지 획득/사용 이력
+ * - 획득/사용 내역을 모두 기록 (감사 로그 + 향후 통계용)
+ */
+@Entity
+@Table(name = "honey_jar_histories", indexes = {
+        @Index(name = "idx_honey_jar_history_user_id", columnList = "user_id")
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HoneyJarHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
+    private Long historyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 변동 유형 (획득/사용)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_type", nullable = false)
+    private HoneyJarAction actionType;
+
+    // 변동 수량 (양수: 획득, 음수: 사용)
+    @Column(name = "amount", nullable = false)
+    private Integer amount;
+
+    // 변동 사유
+    @Column(name = "reason", nullable = false, length = 200)
+    private String reason;
+
+    // 변동 후 잔액
+    @Column(name = "balance_after", nullable = false)
+    private Integer balanceAfter;
+
+    // 관련 동화 ID (선택)
+    @Column(name = "story_id")
+    private Long storyId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarHistoryRepository.java
+++ b/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarHistoryRepository.java
@@ -1,0 +1,15 @@
+package com.moretale.domain.honeyjar.repository;
+
+import com.moretale.domain.honeyjar.entity.HoneyJarHistory;
+import com.moretale.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HoneyJarHistoryRepository extends JpaRepository<HoneyJarHistory, Long> {
+
+    // 사용자 꿀단지 이력 조회 (최신순)
+    List<HoneyJarHistory> findByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarRepository.java
+++ b/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarRepository.java
@@ -1,0 +1,24 @@
+package com.moretale.domain.honeyjar.repository;
+
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+
+@Repository
+public interface HoneyJarRepository extends JpaRepository<HoneyJar, Long> {
+
+    // 사용자로 꿀단지 조회
+    Optional<HoneyJar> findByUser(User user);
+
+    // 동시성 제어를 위한 비관적 락 조회 (꿀단지 차감 시 사용)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT h FROM HoneyJar h WHERE h.user = :user")
+    Optional<HoneyJar> findByUserWithLock(@Param("user") User user);
+}

--- a/src/main/java/com/moretale/domain/honeyjar/service/HoneyJarService.java
+++ b/src/main/java/com/moretale/domain/honeyjar/service/HoneyJarService.java
@@ -1,0 +1,134 @@
+package com.moretale.domain.honeyjar.service;
+
+import com.moretale.domain.honeyjar.dto.HoneyJarHistoryResponse;
+import com.moretale.domain.honeyjar.dto.HoneyJarResponse;
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.honeyjar.entity.HoneyJarAction;
+import com.moretale.domain.honeyjar.entity.HoneyJarHistory;
+import com.moretale.domain.honeyjar.repository.HoneyJarHistoryRepository;
+import com.moretale.domain.honeyjar.repository.HoneyJarRepository;
+import com.moretale.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 꿀단지 보상 관리 서비스
+ * - 꿀단지 획득/사용/조회 처리
+ * - 20개 달성 시 자동 차감 로직 처리
+ * - 꿀단지 이력 조회 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HoneyJarService {
+
+    private final HoneyJarRepository honeyJarRepository;
+    private final HoneyJarHistoryRepository honeyJarHistoryRepository;
+
+    private static final int FREE_GENERATION_THRESHOLD = 20;
+
+    // 꿀단지 현황 조회
+    // 최초 조회 시 레코드가 없으면 생성
+    @Transactional
+    public HoneyJarResponse getHoneyJar(User user) {
+        HoneyJar honeyJar = getOrCreateHoneyJar(user);
+        return HoneyJarResponse.from(honeyJar);
+    }
+
+    // 꿀단지 이력 조회(최신순)
+    @Transactional(readOnly = true)
+    public List<HoneyJarHistoryResponse> getHoneyJarHistory(User user) {
+        return honeyJarHistoryRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(HoneyJarHistoryResponse::from)
+                .toList();
+    }
+
+    /**
+     * 꿀단지 지급 및 20개 달성 시 자동 차감 처리
+     *
+     * @param user 사용자 엔티티
+     * @param action 지급 사유
+     * @param storyId 관련 동화 ID
+     * @return 자동 차감 발생 여부
+     */
+    @Transactional
+    public boolean addHoneyJarAndCheckAutoUse(User user, HoneyJarAction action, Long storyId) {
+        // 동시성 제어를 위해 비관적 락 사용
+        HoneyJar honeyJar = honeyJarRepository.findByUserWithLock(user)
+                .orElseGet(() -> createHoneyJar(user));
+
+        // 꿀단지 1개 지급
+        honeyJar.add(1);
+        honeyJarRepository.save(honeyJar);
+
+        // 지급 이력 저장
+        saveHistory(user, action, 1, honeyJar.getCount(), storyId);
+
+        log.info("꿀단지 지급 완료 - userId={}, action={}, 현재 잔액={}",
+                user.getUserId(), action, honeyJar.getCount());
+
+        // 20개 달성 시 자동 차감
+        if (honeyJar.canGenerateFree()) {
+            boolean used = honeyJar.use(FREE_GENERATION_THRESHOLD);
+
+            if (used) {
+                honeyJarRepository.save(honeyJar);
+
+                // 사용 이력 저장
+                saveHistory(
+                        user,
+                        HoneyJarAction.USE_FREE_GENERATION,
+                        -FREE_GENERATION_THRESHOLD,
+                        honeyJar.getCount(),
+                        storyId
+                );
+
+                log.info("꿀단지 20개 달성 및 자동 차감 완료 - userId={}, 남은 잔액={}",
+                        user.getUserId(), honeyJar.getCount());
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // 꿀단지 조회 또는 신규 생성
+    @Transactional
+    public HoneyJar getOrCreateHoneyJar(User user) {
+        return honeyJarRepository.findByUser(user)
+                .orElseGet(() -> createHoneyJar(user));
+    }
+
+    // 꿀단지 변동 이력 저장
+    private void saveHistory(User user, HoneyJarAction action, int amount, int balanceAfter, Long storyId) {
+        HoneyJarHistory history = HoneyJarHistory.builder()
+                .user(user)
+                .actionType(action)
+                .amount(amount)
+                .reason(action.getDescription())
+                .balanceAfter(balanceAfter)
+                .storyId(storyId)
+                .build();
+
+        honeyJarHistoryRepository.save(history);
+    }
+
+    // 꿀단지 엔티티 신규 생성
+    private HoneyJar createHoneyJar(User user) {
+        HoneyJar newHoneyJar = HoneyJar.builder()
+                .user(user)
+                .count(0)
+                .totalEarned(0)
+                .totalUsed(0)
+                .build();
+
+        return honeyJarRepository.save(newHoneyJar);
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/moretale/domain/quiz/controller/QuizController.java
@@ -1,0 +1,119 @@
+package com.moretale.domain.quiz.controller;
+
+import com.moretale.domain.honeyjar.service.HoneyJarService;
+import com.moretale.domain.quiz.dto.*;
+import com.moretale.domain.quiz.service.QuizService;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Quiz", description = "퀴즈 & 꿀단지 보상 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    /**
+     * 퀴즈 조회 (없으면 자동 생성)
+     * GET /api/quiz?storyId={storyId}
+     *
+     * - 동화 1권당 퀴즈 1세트 자동 생성
+     * - 이미 생성된 경우 기존 퀴즈 반환
+     * - 정답은 응답에 포함되지 않음 (서버에서만 처리)
+     */
+    @Operation(
+            summary = "퀴즈 조회",
+            description = """
+                    동화에 연결된 퀴즈를 조회합니다.
+                    퀴즈가 없으면 AI가 자동으로 생성합니다.
+                    
+                    - 정답은 응답에 포함되지 않습니다 (채점은 서버에서 처리)
+                    - 난이도는 사용자 프로필(연령/언어수준) 기반으로 자동 결정
+                    - 문제 언어는 동화의 primaryLanguage 기준
+                    """
+    )
+    @GetMapping
+    public ApiResponse<QuizResponse> getQuiz(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(name = "storyId") Long storyId
+    ) {
+        log.info("퀴즈 조회 요청 - email={}, storyId={}", userDetails.getUsername(), storyId);
+
+        QuizResponse response = quizService.getOrGenerateQuiz(userDetails.getUsername(), storyId);
+        return ApiResponse.success(response, "퀴즈 조회 성공");
+    }
+
+    /**
+     * 퀴즈 제출 및 채점
+     * POST /api/quiz/submit
+     *
+     * - 서버에서 정답 판별 및 점수 계산 (클라이언트 의존 없음)
+     * - 100점 달성 시 꿀단지 +1 자동 지급
+     * - 동화 1권당 퀴즈 보상은 최초 1회만 지급
+     */
+    @Operation(
+            summary = "퀴즈 제출",
+            description = """
+                    퀴즈 답안을 제출하고 채점 결과를 받습니다.
+                    
+                    **채점 규칙**
+                    - 선다형: 보기 번호("1"~"4") 제출
+                    - T/F형: "TRUE" 또는 "FALSE" 제출
+                    - 점수 = (정답 수 / 총 문제 수) × 100
+                    
+                    **꿀단지 보상**
+                    - 100점 달성 시 꿀단지 +1 (동화 1권당 최초 1회)
+                    - 꿀단지 20개 달성 시 동화 1권 무료 생성 자동 처리
+                    """
+    )
+    @PostMapping("/submit")
+    public ApiResponse<QuizResultResponse> submitQuiz(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody QuizSubmitRequest request
+    ) {
+        log.info("퀴즈 제출 요청 - email={}, quizId={}", userDetails.getUsername(), request.getQuizId());
+
+        QuizResultResponse response = quizService.submitQuiz(userDetails.getUsername(), request);
+        return ApiResponse.success(response, "퀴즈 채점 완료");
+    }
+
+    /**
+     * 동화 완독 처리
+     * POST /api/quiz/story-complete
+     *
+     * - 동화 완독 시 꿀단지 +1 지급
+     * - 중복 지급 방지 (동화 1권당 최초 1회)
+     */
+    @Operation(
+            summary = "동화 완독 처리",
+            description = """
+                    동화를 끝까지 읽었을 때 호출합니다.
+                    
+                    **꿀단지 보상**
+                    - 완독 시 꿀단지 +1 (동화 1권당 최초 1회)
+                    - 꿀단지 20개 달성 시 동화 1권 무료 생성 자동 처리
+                    """
+    )
+    @PostMapping("/story-complete")
+    public ApiResponse<QuizResultResponse.HoneyJarRewardInfo> completeStory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody StoryCompleteRequest request
+    ) {
+        log.info("동화 완독 요청 - email={}, storyId={}", userDetails.getUsername(), request.getStoryId());
+
+        QuizResultResponse.HoneyJarRewardInfo rewardInfo =
+                quizService.completeStory(userDetails.getUsername(), request.getStoryId());
+
+        return ApiResponse.success(rewardInfo, "동화 완독 처리 완료");
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/dto/QuizResponse.java
+++ b/src/main/java/com/moretale/domain/quiz/dto/QuizResponse.java
@@ -1,0 +1,78 @@
+package com.moretale.domain.quiz.dto;
+
+import com.moretale.domain.quiz.entity.*;
+import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// GET /api/quiz?storyId={storyId} 응답 DTO
+// 정답은 포함하지 않음 (채점은 서버에서만 처리)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizResponse {
+
+    private Long quizId;
+    private Long storyId;
+    private String language;
+    private String difficulty;
+    private Integer totalQuestions;
+    private List<QuestionDto> questions;
+
+    public static QuizResponse from(Quiz quiz) {
+        return QuizResponse.builder()
+                .quizId(quiz.getQuizId())
+                .storyId(quiz.getStory().getStoryId())
+                .language(quiz.getLanguage())
+                .difficulty(quiz.getDifficulty().getDescription())
+                .totalQuestions(quiz.getTotalQuestions())
+                .questions(quiz.getQuestions().stream()
+                        .map(QuestionDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionDto {
+        private Long questionId;
+        private Integer questionOrder;
+        private String questionType;
+        private String evaluationType;
+        private String questionText;
+        private List<OptionDto> options; // T/F는 빈 리스트
+
+        public static QuestionDto from(QuizQuestion question) {
+            return QuestionDto.builder()
+                    .questionId(question.getQuestionId())
+                    .questionOrder(question.getQuestionOrder())
+                    .questionType(question.getQuestionType().name())
+                    .evaluationType(question.getEvaluationType().getDescription())
+                    .questionText(question.getQuestionText())
+                    .options(question.getOptions().stream()
+                            .map(OptionDto::from)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionDto {
+        private Integer optionOrder;
+        private String optionText;
+
+        public static OptionDto from(QuizOption option) {
+            return OptionDto.builder()
+                    .optionOrder(option.getOptionOrder())
+                    .optionText(option.getOptionText())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/dto/QuizResultResponse.java
+++ b/src/main/java/com/moretale/domain/quiz/dto/QuizResultResponse.java
@@ -1,0 +1,99 @@
+package com.moretale.domain.quiz.dto;
+
+import com.moretale.domain.quiz.entity.QuizAnswerRecord;
+import com.moretale.domain.quiz.entity.QuizResult;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * POST /api/quiz/submit 응답 DTO
+ * - 채점 결과 + 꿀단지 보상 정보 포함
+ * - 프론트에서 결과 화면 렌더링에 필요한 모든 정보 제공
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizResultResponse {
+
+    // 채점 결과
+    private Long resultId;
+    private Integer score;           // 점수 (0~100)
+    private Integer totalQuestions;
+    private Integer correctCount;
+    private Boolean isPerfect;       // 100점 여부
+
+    // 꿀단지 보상 정보
+    private HoneyJarRewardInfo honeyJarReward;
+
+    // 문항별 정오 내역
+    private List<AnswerResultDto> answerResults;
+
+    // 프론트에서 사용할 상태 메시지
+    private String resultMessage;
+
+    public static QuizResultResponse of(
+            QuizResult result,
+            HoneyJarRewardInfo rewardInfo,
+            List<AnswerResultDto> answerResults
+    ) {
+        String message = buildResultMessage(result.getScore(), result.getIsPerfect());
+
+        return QuizResultResponse.builder()
+                .resultId(result.getResultId())
+                .score(result.getScore())
+                .totalQuestions(result.getTotalQuestions())
+                .correctCount(result.getCorrectCount())
+                .isPerfect(result.getIsPerfect())
+                .honeyJarReward(rewardInfo)
+                .answerResults(answerResults)
+                .resultMessage(message)
+                .build();
+    }
+
+    private static String buildResultMessage(int score, boolean isPerfect) {
+        if (isPerfect) return "🎉 완벽해요! 모든 문제를 맞혔어요!";
+        if (score >= 80) return "👏 훌륭해요! 거의 다 맞혔어요!";
+        if (score >= 60) return "😊 잘했어요! 조금만 더 읽어봐요!";
+        return "📚 동화를 다시 읽고 도전해봐요!";
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HoneyJarRewardInfo {
+        private Integer earnedHoneyJars;        // 이번에 획득한 꿀단지 수
+        private Integer currentHoneyJarCount;   // 현재 보유 꿀단지 수
+        private Boolean canGenerateFree;        // 무료 생성 가능 여부 (20개 이상)
+        private Boolean autoUsedForFreeGeneration; // 20개 달성 시 자동 차감 여부
+        private String rewardMessage;           // 보상 관련 메시지
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnswerResultDto {
+        private Long questionId;
+        private Integer questionOrder;
+        private String questionText;
+        private String submittedAnswer;
+        private String correctAnswer;
+        private Boolean isCorrect;
+        private String explanation;
+
+        public static AnswerResultDto from(QuizAnswerRecord record) {
+            return AnswerResultDto.builder()
+                    .questionId(record.getQuestion().getQuestionId())
+                    .questionOrder(record.getQuestion().getQuestionOrder())
+                    .questionText(record.getQuestion().getQuestionText())
+                    .submittedAnswer(record.getSubmittedAnswer())
+                    .correctAnswer(record.getQuestion().getCorrectAnswer())
+                    .isCorrect(record.getIsCorrect())
+                    .explanation(record.getQuestion().getExplanation())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/dto/QuizSubmitRequest.java
+++ b/src/main/java/com/moretale/domain/quiz/dto/QuizSubmitRequest.java
@@ -1,0 +1,37 @@
+package com.moretale.domain.quiz.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+// POST /api/quiz/submit 요청 DTO
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizSubmitRequest {
+
+    @NotNull(message = "퀴즈 ID는 필수입니다.")
+    private Long quizId;
+
+    @NotEmpty(message = "답안은 최소 1개 이상이어야 합니다.")
+    @Valid
+    private List<AnswerDto> answers;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnswerDto {
+
+        @NotNull(message = "문제 ID는 필수입니다.")
+        private Long questionId;
+
+        @NotNull(message = "답안은 필수입니다.")
+        private String submittedAnswer; // 선다형: "1"~"4", T/F: "TRUE"/"FALSE"
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/dto/StoryCompleteRequest.java
+++ b/src/main/java/com/moretale/domain/quiz/dto/StoryCompleteRequest.java
@@ -1,0 +1,17 @@
+package com.moretale.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+// POST /api/quiz/story-complete 요청 DTO
+// 동화 완독 시 꿀단지 지급 요청
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoryCompleteRequest {
+
+    @NotNull(message = "동화 ID는 필수입니다.")
+    private Long storyId;
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/EvaluationType.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/EvaluationType.java
@@ -1,0 +1,13 @@
+package com.moretale.domain.quiz.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EvaluationType {
+    VOCABULARY("단어 이해"),    // 단어 뜻을 알아야 풀 수 있는 문제
+    STORY("줄거리 이해");       // 내용을 읽어야 풀 수 있는 문제
+
+    private final String description;
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuestionType.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuestionType.java
@@ -1,0 +1,13 @@
+package com.moretale.domain.quiz.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionType {
+    MULTIPLE_CHOICE("선다형"),   // 4지 선다형
+    TRUE_FALSE("참/거짓");       // T/F형
+
+    private final String description;
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/Quiz.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/Quiz.java
@@ -1,0 +1,66 @@
+package com.moretale.domain.quiz.entity;
+
+import com.moretale.domain.story.entity.Story;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 동화 1권에 연결된 퀴즈 세트
+ * - 동화 1권당 퀴즈 1세트 (5~10문제)
+ * - primaryLanguage 기준으로 문제 언어 결정
+ */
+@Entity
+@Table(name = "quizzes", indexes = {
+        @Index(name = "idx_quiz_story_id", columnList = "story_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Quiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quiz_id")
+    private Long quizId;
+
+    // 연결된 동화 (동화 1권 = 퀴즈 1세트)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id", nullable = false, unique = true)
+    private Story story;
+
+    // 문제 언어 (primaryLanguage 기준)
+    @Column(name = "language", nullable = false, length = 10)
+    private String language;
+
+    // 난이도 (연령 및 언어 수준 기반)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false)
+    private QuizDifficulty difficulty;
+
+    // 총 문제 수 (5~10개)
+    @Column(name = "total_questions", nullable = false)
+    private Integer totalQuestions;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 퀴즈 문제 목록
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("questionOrder ASC")
+    @Builder.Default
+    private List<QuizQuestion> questions = new ArrayList<>();
+
+    // 편의 메서드
+    public void addQuestion(QuizQuestion question) {
+        questions.add(question);
+        question.setQuiz(this);
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuizAnswerRecord.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuizAnswerRecord.java
@@ -1,0 +1,37 @@
+package com.moretale.domain.quiz.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+// 퀴즈 개별 문항 응답 기록
+// 오답노트, 학습 통계, 개인화 추천 기능 확장 가능하도록 설계
+@Entity
+@Table(name = "quiz_answer_records")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizAnswerRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long recordId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "result_id", nullable = false)
+    private QuizResult quizResult;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private QuizQuestion question;
+
+    // 사용자가 제출한 답
+    @Column(name = "submitted_answer", nullable = false, length = 20)
+    private String submittedAnswer;
+
+    // 정답 여부
+    @Column(name = "is_correct", nullable = false)
+    private Boolean isCorrect;
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuizDifficulty.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuizDifficulty.java
@@ -1,0 +1,32 @@
+package com.moretale.domain.quiz.entity;
+
+import com.moretale.domain.profile.entity.AgeGroup;
+import com.moretale.domain.profile.entity.LanguageProficiency;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+// 퀴즈 난이도
+// 연령 그룹 + 언어 숙련도를 조합하여 결정
+@Getter
+@RequiredArgsConstructor
+public enum QuizDifficulty {
+    EASY("쉬움", 5),      // 0~4세, EGG/LARVA
+    NORMAL("보통", 7),    // 5~8세, LARVA/PUPA
+    HARD("어려움", 10);   // 9세 이상, PUPA/BEE
+
+    private final String description;
+    private final int questionCount; // 난이도별 문제 수
+
+    // 연령 그룹 + 언어 숙련도 → 난이도 결정
+    public static QuizDifficulty from(AgeGroup ageGroup, LanguageProficiency proficiency) {
+        int ageScore = ageGroup.getRepresentativeAge();
+        int langScore = proficiency.getLevel();
+
+        // 복합 점수: 나이 가중치 60% + 언어 숙련도 40%
+        double compositeScore = ageScore * 0.6 + langScore * 3 * 0.4;
+
+        if (compositeScore <= 3.0) return EASY;
+        if (compositeScore <= 6.0) return NORMAL;
+        return HARD;
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuizOption.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuizOption.java
@@ -1,0 +1,36 @@
+package com.moretale.domain.quiz.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 선다형 문제의 보기 항목
+ * - optionOrder: 1~4번 보기 순서
+ * - optionText: 보기 내용
+ */
+@Entity
+@Table(name = "quiz_options")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "option_id")
+    private Long optionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private QuizQuestion question;
+
+    // 보기 순서 (1~4)
+    @Column(name = "option_order", nullable = false)
+    private Integer optionOrder;
+
+    // 보기 내용
+    @Column(name = "option_text", nullable = false, columnDefinition = "TEXT")
+    private String optionText;
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuizQuestion.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuizQuestion.java
@@ -1,0 +1,76 @@
+package com.moretale.domain.quiz.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 퀴즈 개별 문제
+ * - 선다형(MULTIPLE_CHOICE) / T/F(TRUE_FALSE) 지원
+ * - 단어 이해 + 줄거리 이해 복합 평가
+ */
+@Entity
+@Table(name = "quiz_questions", indexes = {
+        @Index(name = "idx_quiz_question_quiz_id", columnList = "quiz_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long questionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    // 문제 유형 (선다형 / T/F)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type", nullable = false)
+    private QuestionType questionType;
+
+    // 평가 유형 (단어 이해 / 줄거리 이해)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "evaluation_type", nullable = false)
+    private EvaluationType evaluationType;
+
+    // 문제 번호 (1부터 시작)
+    @Column(name = "question_order", nullable = false)
+    private Integer questionOrder;
+
+    // 문제 내용
+    @Column(name = "question_text", nullable = false, columnDefinition = "TEXT")
+    private String questionText;
+
+    // 정답 (선다형: "1"~"4", T/F: "TRUE"/"FALSE")
+    @Column(name = "correct_answer", nullable = false, length = 10)
+    private String correctAnswer;
+
+    // 해설
+    @Column(name = "explanation", columnDefinition = "TEXT")
+    private String explanation;
+
+    // 선다형 보기 목록 (T/F는 비어있음)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("optionOrder ASC")
+    @Builder.Default
+    private List<QuizOption> options = new ArrayList<>();
+
+    // 편의 메서드
+    public void addOption(QuizOption option) {
+        options.add(option);
+        option.setQuestion(this);
+    }
+
+    // 정답 여부 판별
+    public boolean isCorrect(String answer) {
+        return this.correctAnswer.equalsIgnoreCase(answer != null ? answer.trim() : "");
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/QuizResult.java
@@ -1,0 +1,79 @@
+package com.moretale.domain.quiz.entity;
+
+import com.moretale.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 퀴즈 응시 결과
+ * - 사용자가 퀴즈를 제출할 때마다 생성
+ * - 점수, 정답 여부, 꿀단지 지급 여부 저장
+ */
+@Entity
+@Table(name = "quiz_results", indexes = {
+        @Index(name = "idx_quiz_result_user_id", columnList = "user_id"),
+        @Index(name = "idx_quiz_result_quiz_id", columnList = "quiz_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "result_id")
+    private Long resultId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    // 획득 점수 (0~100)
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    // 총 문제 수
+    @Column(name = "total_questions", nullable = false)
+    private Integer totalQuestions;
+
+    // 맞은 문제 수
+    @Column(name = "correct_count", nullable = false)
+    private Integer correctCount;
+
+    // 만점(100점) 여부
+    @Column(name = "is_perfect", nullable = false)
+    @Builder.Default
+    private Boolean isPerfect = false;
+
+    // 퀴즈 보상 꿀단지 지급 여부 (100점 시 1개 추가)
+    @Column(name = "honey_jar_rewarded", nullable = false)
+    @Builder.Default
+    private Boolean honeyJarRewarded = false;
+
+    // 응시 일시
+    @CreationTimestamp
+    @Column(name = "submitted_at", nullable = false, updatable = false)
+    private LocalDateTime submittedAt;
+
+    // 개별 문항 응답 내역
+    @OneToMany(mappedBy = "quizResult", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<QuizAnswerRecord> answerRecords = new ArrayList<>();
+
+    // 편의 메서드: 점수 계산
+    public static int calculateScore(int correctCount, int totalQuestions) {
+        if (totalQuestions == 0) return 0;
+        return (int) Math.round((double) correctCount / totalQuestions * 100);
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/entity/StoryReadStatus.java
+++ b/src/main/java/com/moretale/domain/quiz/entity/StoryReadStatus.java
@@ -1,0 +1,69 @@
+package com.moretale.domain.quiz.entity;
+
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 동화 완독 상태
+ * - 완독 여부와 꿀단지 지급 여부를 별도 추적
+ * - 동화 1권당 최대 2개 꿀단지 제한 관리 (완독 1개 + 퀴즈 1개)
+ */
+@Entity
+@Table(name = "story_read_statuses",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_story_read_status_user_story",
+                columnNames = {"user_id", "story_id"}
+        ))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoryReadStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "status_id")
+    private Long statusId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id", nullable = false)
+    private Story story;
+
+    // 완독 여부
+    @Column(name = "is_completed", nullable = false)
+    @Builder.Default
+    private Boolean isCompleted = false;
+
+    // 완독 보상 꿀단지 지급 여부
+    @Column(name = "read_honey_jar_rewarded", nullable = false)
+    @Builder.Default
+    private Boolean readHoneyJarRewarded = false;
+
+    // 퀴즈 보상 꿀단지 지급 여부
+    @Column(name = "quiz_honey_jar_rewarded", nullable = false)
+    @Builder.Default
+    private Boolean quizHoneyJarRewarded = false;
+
+    // 완독 일시
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 이 동화에서 받을 수 있는 꿀단지를 모두 받았는지 확인 (최대 2개 제한)
+    public boolean isFullyRewarded() {
+        return readHoneyJarRewarded && quizHoneyJarRewarded;
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/moretale/domain/quiz/repository/QuizRepository.java
@@ -1,0 +1,41 @@
+package com.moretale.domain.quiz.repository;
+
+import com.moretale.domain.quiz.entity.Quiz;
+import com.moretale.domain.story.entity.Story;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+// Quiz 엔티티에 대한 데이터 액세스 레포지토리
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+
+    /**
+     * 동화(Story)를 기준으로 퀴즈 세트를 조회합니다.
+     * MultipleBagFetchException 해결을 위해 qq.options에 대한 FETCH JOIN을 제거했습니다.
+     * 질문(questions) 리스트는 FETCH JOIN으로 가져오고, 각 질문의 보기(options)는
+     * application.yml의 default_batch_fetch_size 설정을 통해 배치 조회됩니다.
+     */
+    @Query("SELECT q FROM Quiz q " +
+            "LEFT JOIN FETCH q.questions qq " +
+            "WHERE q.story = :story")
+    Optional<Quiz> findByStoryWithQuestions(@Param("story") Story story);
+
+    /**
+     * 퀴즈 ID를 기준으로 퀴즈 세트를 조회합니다. (채점 시 사용)
+     * MultipleBagFetchException 방지를 위해 qq.options FETCH JOIN을 제거했습니다.
+     */
+    @Query("SELECT q FROM Quiz q " +
+            "LEFT JOIN FETCH q.questions qq " +
+            "WHERE q.quizId = :quizId")
+    Optional<Quiz> findByIdWithQuestions(@Param("quizId") Long quizId);
+
+    // 특정 동화에 이미 생성된 퀴즈가 있는지 확인
+    boolean existsByStory(Story story);
+
+    // 동화 엔티티를 기준으로 퀴즈를 조회 (페치 조인 없는 단순 조회)
+    Optional<Quiz> findByStory(Story story);
+}

--- a/src/main/java/com/moretale/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/moretale/domain/quiz/repository/QuizResultRepository.java
@@ -1,0 +1,29 @@
+package com.moretale.domain.quiz.repository;
+
+import com.moretale.domain.quiz.entity.Quiz;
+import com.moretale.domain.quiz.entity.QuizResult;
+import com.moretale.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
+
+    // 사용자 + 퀴즈로 가장 최근 결과 조회
+    Optional<QuizResult> findTopByUserAndQuizOrderBySubmittedAtDesc(User user, Quiz quiz);
+
+    // 사용자 + 퀴즈로 100점 달성 여부 확인
+    boolean existsByUserAndQuizAndIsPerfectTrue(User user, Quiz quiz);
+
+    // 사용자의 퀴즈 응시 이력 전체 조회
+    List<QuizResult> findByUserOrderBySubmittedAtDesc(User user);
+
+    // 특정 퀴즈에서 사용자의 응시 횟수
+    @Query("SELECT COUNT(r) FROM QuizResult r WHERE r.user = :user AND r.quiz = :quiz")
+    int countByUserAndQuiz(@Param("user") User user, @Param("quiz") Quiz quiz);
+}

--- a/src/main/java/com/moretale/domain/quiz/repository/StoryReadStatusRepository.java
+++ b/src/main/java/com/moretale/domain/quiz/repository/StoryReadStatusRepository.java
@@ -1,0 +1,19 @@
+package com.moretale.domain.quiz.repository;
+
+import com.moretale.domain.quiz.entity.StoryReadStatus;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StoryReadStatusRepository extends JpaRepository<StoryReadStatus, Long> {
+
+    // 사용자 + 동화로 완독 상태 조회
+    Optional<StoryReadStatus> findByUserAndStory(User user, Story story);
+
+    // 완독 상태 존재 여부 확인
+    boolean existsByUserAndStory(User user, Story story);
+}

--- a/src/main/java/com/moretale/domain/quiz/service/AIQuizService.java
+++ b/src/main/java/com/moretale/domain/quiz/service/AIQuizService.java
@@ -1,0 +1,28 @@
+package com.moretale.domain.quiz.service;
+
+import com.moretale.domain.quiz.entity.QuizDifficulty;
+import com.moretale.domain.quiz.entity.QuizQuestion;
+import com.moretale.domain.story.entity.Story;
+
+import java.util.List;
+
+// AI 기반 퀴즈 생성 서비스 인터페이스
+// LLM을 통해 동화 내용 기반 퀴즈 문제를 생성
+public interface AIQuizService {
+
+    /**
+     * 동화 내용 기반 퀴즈 문제 생성
+     *
+     * @param story      대상 동화
+     * @param difficulty 난이도
+     * @param language   문제 언어 (primaryLanguage)
+     * @param count      생성할 문제 수
+     * @return 생성된 문제 목록 (저장 전 상태)
+     */
+    List<QuizQuestion> generateQuestions(
+            Story story,
+            QuizDifficulty difficulty,
+            String language,
+            int count
+    );
+}

--- a/src/main/java/com/moretale/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/moretale/domain/quiz/service/QuizService.java
@@ -1,0 +1,303 @@
+package com.moretale.domain.quiz.service;
+
+import com.moretale.domain.honeyjar.entity.HoneyJarAction;
+import com.moretale.domain.honeyjar.service.HoneyJarService;
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.quiz.dto.*;
+import com.moretale.domain.quiz.entity.*;
+import com.moretale.domain.quiz.repository.*;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 퀴즈 & 꿀단지 핵심 서비스
+ *
+ * 퀴즈 흐름:
+ *  1. GET /api/quiz?storyId=N  → 퀴즈 없으면 자동 생성, 있으면 조회
+ *  2. POST /api/quiz/submit    → 채점 → 꿀단지 보상 처리
+ *
+ * 꿀단지 흐름:
+ *  - 동화 완독: POST /api/quiz/story-complete → +1
+ *  - 퀴즈 100점: submit 채점 후 자동 → +1
+ *  - 20개 달성 시 → 자동 -20 (무료 생성 1회)
+ *  - 동화 1권당 최대 2개 (완독 1 + 퀴즈 1) 제한
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizService {
+
+    private final QuizRepository quizRepository;
+    private final QuizResultRepository quizResultRepository;
+    private final StoryReadStatusRepository storyReadStatusRepository;
+    private final StoryRepository storyRepository;
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final AIQuizService aiQuizService;
+    private final HoneyJarService honeyJarService;
+
+    // 퀴즈 조회 (없으면 자동 생성)
+    // GET /api/quiz?storyId={storyId}
+    @Transactional
+    public QuizResponse getOrGenerateQuiz(String email, Long storyId) {
+        User user = getUserByEmail(email);
+        Story story = getStoryWithAccess(user, storyId);
+
+        // 기존 퀴즈가 있으면 바로 반환
+        Quiz existingQuiz = quizRepository.findByStoryWithQuestions(story).orElse(null);
+        if (existingQuiz != null) {
+            log.info("기존 퀴즈 반환 - storyId={}, quizId={}", storyId, existingQuiz.getQuizId());
+            return QuizResponse.from(existingQuiz);
+        }
+
+        // 없으면 새로 생성
+        log.info("퀴즈 신규 생성 시작 - storyId={}", storyId);
+        Quiz newQuiz = generateQuiz(user, story);
+        return QuizResponse.from(newQuiz);
+    }
+
+    // 퀴즈 채점 및 꿀단지 보상
+    // POST /api/quiz/submit
+    @Transactional
+    public QuizResultResponse submitQuiz(String email, QuizSubmitRequest request) {
+        User user = getUserByEmail(email);
+
+        // 퀴즈 조회 (문제 + 보기 포함)
+        Quiz quiz = quizRepository.findByIdWithQuestions(request.getQuizId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUIZ_NOT_FOUND));
+
+        // 문제 ID → QuizQuestion 맵 구성
+        Map<Long, QuizQuestion> questionMap = quiz.getQuestions().stream()
+                .collect(Collectors.toMap(QuizQuestion::getQuestionId, q -> q));
+
+        // 채점 처리
+        int correctCount = 0;
+        List<QuizAnswerRecord> answerRecords = new ArrayList<>();
+        List<QuizResultResponse.AnswerResultDto> answerResults = new ArrayList<>();
+
+        for (QuizSubmitRequest.AnswerDto answer : request.getAnswers()) {
+            QuizQuestion question = questionMap.get(answer.getQuestionId());
+            if (question == null) {
+                log.warn("존재하지 않는 문제 ID - questionId={}", answer.getQuestionId());
+                continue;
+            }
+
+            boolean isCorrect = question.isCorrect(answer.getSubmittedAnswer());
+            if (isCorrect) correctCount++;
+
+            QuizAnswerRecord record = QuizAnswerRecord.builder()
+                    .question(question)
+                    .submittedAnswer(answer.getSubmittedAnswer())
+                    .isCorrect(isCorrect)
+                    .build();
+
+            answerRecords.add(record);
+            answerResults.add(QuizResultResponse.AnswerResultDto.from(record));
+        }
+
+        int totalQuestions = quiz.getQuestions().size();
+        int score = QuizResult.calculateScore(correctCount, totalQuestions);
+        boolean isPerfect = (score == 100);
+
+        // QuizResult 저장
+        QuizResult quizResult = QuizResult.builder()
+                .user(user)
+                .quiz(quiz)
+                .score(score)
+                .totalQuestions(totalQuestions)
+                .correctCount(correctCount)
+                .isPerfect(isPerfect)
+                .honeyJarRewarded(false)
+                .build();
+
+        answerRecords.forEach(record -> {
+            record.setQuizResult(quizResult);
+            quizResult.getAnswerRecords().add(record);
+        });
+
+        quizResultRepository.save(quizResult);
+
+        log.info("퀴즈 채점 완료 - userId={}, quizId={}, score={}, isPerfect={}",
+                user.getUserId(), quiz.getQuizId(), score, isPerfect);
+
+        // 꿀단지 보상 처리
+        QuizResultResponse.HoneyJarRewardInfo rewardInfo = processHoneyJarReward(
+                user, quiz, quizResult, isPerfect
+        );
+
+        return QuizResultResponse.of(quizResult, rewardInfo, answerResults);
+    }
+
+    // 동화 완독 처리 + 꿀단지 지급
+    // POST /api/quiz/story-complete
+    @Transactional
+    public QuizResultResponse.HoneyJarRewardInfo completeStory(String email, Long storyId) {
+        User user = getUserByEmail(email);
+        Story story = getStoryWithAccess(user, storyId);
+
+        // 완독 상태 조회 또는 생성
+        StoryReadStatus readStatus = storyReadStatusRepository
+                .findByUserAndStory(user, story)
+                .orElseGet(() -> StoryReadStatus.builder()
+                        .user(user)
+                        .story(story)
+                        .build());
+
+        // 이미 완독 보상을 받은 경우 중복 지급 방지
+        if (Boolean.TRUE.equals(readStatus.getReadHoneyJarRewarded())) {
+            log.info("이미 완독 보상 지급됨 - userId={}, storyId={}", user.getUserId(), storyId);
+
+            var honeyJar = honeyJarService.getOrCreateHoneyJar(user);
+            return buildRewardInfo(0, honeyJar.getCount(), false, "이미 완독 보상을 받으셨어요! 🍯");
+        }
+
+        // 완독 처리
+        readStatus.setIsCompleted(true);
+        readStatus.setCompletedAt(LocalDateTime.now());
+        readStatus.setReadHoneyJarRewarded(true);
+        storyReadStatusRepository.save(readStatus);
+
+        // 꿀단지 +1 지급 및 자동 차감 확인
+        boolean autoUsed = honeyJarService.addHoneyJarAndCheckAutoUse(
+                user, HoneyJarAction.EARN_STORY_COMPLETE, storyId
+        );
+
+        var honeyJar = honeyJarService.getOrCreateHoneyJar(user);
+        String message = autoUsed
+                ? "🎉 꿀단지 20개 달성! 동화 1권을 무료로 만들 수 있어요!"
+                : "📖 동화를 다 읽었어요! 꿀단지 1개 획득! 🍯";
+
+        log.info("동화 완독 처리 완료 - userId={}, storyId={}, 꿀단지자동차감={}",
+                user.getUserId(), storyId, autoUsed);
+
+        return buildRewardInfo(1, honeyJar.getCount(), autoUsed, message);
+    }
+
+    // 내부 메서드: 퀴즈 생성
+    private Quiz generateQuiz(User user, Story story) {
+        // 사용자 프로필에서 난이도 결정
+        UserProfile profile = userProfileRepository
+                .findFirstByUserOrderByCreatedAtDesc(user)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+        QuizDifficulty difficulty = QuizDifficulty.from(
+                profile.getAgeGroup(),
+                profile.getFirstLanguageProficiency()
+        );
+
+        int questionCount = difficulty.getQuestionCount();
+        String language = story.getPrimaryLanguage() != null ? story.getPrimaryLanguage() : "ko";
+
+        // AI 퀴즈 문제 생성
+        List<QuizQuestion> questions = aiQuizService.generateQuestions(
+                story, difficulty, language, questionCount
+        );
+
+        // Quiz 엔티티 조립
+        Quiz quiz = Quiz.builder()
+                .story(story)
+                .language(language)
+                .difficulty(difficulty)
+                .totalQuestions(questions.size())
+                .build();
+
+        questions.forEach(quiz::addQuestion);
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        log.info("퀴즈 생성 완료 - storyId={}, quizId={}, 문제수={}, 난이도={}",
+                story.getStoryId(), savedQuiz.getQuizId(), questions.size(), difficulty);
+
+        return savedQuiz;
+    }
+
+    // 내부 메서드: 퀴즈 100점 꿀단지 보상 처리
+    private QuizResultResponse.HoneyJarRewardInfo processHoneyJarReward(
+            User user, Quiz quiz, QuizResult quizResult, boolean isPerfect
+    ) {
+        Story story = quiz.getStory();
+
+        // 완독 상태 조회 (없으면 초기화)
+        StoryReadStatus readStatus = storyReadStatusRepository
+                .findByUserAndStory(user, story)
+                .orElseGet(() -> storyReadStatusRepository.save(
+                        StoryReadStatus.builder().user(user).story(story).build()
+                ));
+
+        int earnedHoneyJars = 0;
+        boolean autoUsed = false;
+
+        // 100점 + 아직 퀴즈 보상을 받지 않은 경우만 지급
+        if (isPerfect && !Boolean.TRUE.equals(readStatus.getQuizHoneyJarRewarded())) {
+            readStatus.setQuizHoneyJarRewarded(true);
+            storyReadStatusRepository.save(readStatus);
+
+            quizResult.setHoneyJarRewarded(true);
+            quizResultRepository.save(quizResult);
+
+            autoUsed = honeyJarService.addHoneyJarAndCheckAutoUse(
+                    user, HoneyJarAction.EARN_QUIZ_PERFECT, story.getStoryId()
+            );
+            earnedHoneyJars = 1;
+
+            log.info("퀴즈 100점 꿀단지 지급 - userId={}, storyId={}",
+                    user.getUserId(), story.getStoryId());
+        }
+
+        var honeyJar = honeyJarService.getOrCreateHoneyJar(user);
+        String message = buildRewardMessage(isPerfect, earnedHoneyJars, autoUsed,
+                readStatus.getQuizHoneyJarRewarded());
+
+        return buildRewardInfo(earnedHoneyJars, honeyJar.getCount(), autoUsed, message);
+    }
+
+    private String buildRewardMessage(boolean isPerfect, int earned, boolean autoUsed, boolean alreadyRewarded) {
+        if (!isPerfect) return "퀴즈 100점 달성 시 꿀단지를 받을 수 있어요! 🍯";
+        if (alreadyRewarded && earned == 0) return "이미 이 동화에서 퀴즈 보상을 받으셨어요!";
+        if (autoUsed) return "🎉 꿀단지 20개 달성! 동화 1권을 무료로 만들 수 있어요!";
+        return "🏆 100점 달성! 꿀단지 1개 획득! 🍯";
+    }
+
+    private QuizResultResponse.HoneyJarRewardInfo buildRewardInfo(
+            int earned, int currentCount, boolean autoUsed, String message
+    ) {
+        return QuizResultResponse.HoneyJarRewardInfo.builder()
+                .earnedHoneyJars(earned)
+                .currentHoneyJarCount(currentCount)
+                .canGenerateFree(currentCount >= 20)
+                .autoUsedForFreeGeneration(autoUsed)
+                .rewardMessage(message)
+                .build();
+    }
+
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Story getStoryWithAccess(User user, Long storyId) {
+        Story story = storyRepository.findByIdWithSlides(storyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
+
+        // 본인 동화이거나 공개 동화만 퀴즈 가능
+        if (!story.getUser().getUserId().equals(user.getUserId()) && !story.getIsPublic()) {
+            throw new BusinessException(ErrorCode.STORY_ACCESS_DENIED);
+        }
+        return story;
+    }
+}

--- a/src/main/java/com/moretale/domain/quiz/service/impl/AIQuizServiceImpl.java
+++ b/src/main/java/com/moretale/domain/quiz/service/impl/AIQuizServiceImpl.java
@@ -1,0 +1,136 @@
+package com.moretale.domain.quiz.service.impl;
+
+import com.moretale.domain.quiz.entity.*;
+import com.moretale.domain.quiz.service.AIQuizService;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AI 기반 퀴즈 생성 구현체
+ *
+ * TODO: 실제 LLM API 연동 시 아래 프롬프트 구조 참고:
+ *
+ * [시스템 프롬프트]
+ * "당신은 아동 교육용 퀴즈 생성 전문가입니다.
+ *  다음 동화를 읽고, 아이의 단어 이해력과 줄거리 이해력을 동시에 평가하는 퀴즈를 생성하세요.
+ *  - 단어를 모르면 풀 수 없는 VOCABULARY 유형 문제를 {vocabCount}개 생성하세요.
+ *  - 줄거리를 이해해야 풀 수 있는 STORY 유형 문제를 {storyCount}개 생성하세요.
+ *  - 문제 언어: {language}
+ *  - 난이도: {difficulty}
+ *  - 선다형(MULTIPLE_CHOICE)과 참/거짓(TRUE_FALSE)을 혼합하여 생성하세요.
+ *  - 선다형은 4개의 보기를 제공하고, 정답 번호(1~4)를 반환하세요.
+ *  - T/F는 정답을 TRUE 또는 FALSE로 반환하세요.
+ *  - JSON 형식으로만 응답하세요."
+ *
+ * [유저 프롬프트]
+ * "동화 제목: {title}
+ *  동화 내용:
+ *  {slide 텍스트 전체}
+ *  핵심 단어 목록: {highlight 단어들}"
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AIQuizServiceImpl implements AIQuizService {
+
+    @Override
+    public List<QuizQuestion> generateQuestions(
+            Story story,
+            QuizDifficulty difficulty,
+            String language,
+            int count
+    ) {
+        log.info("퀴즈 문제 생성 요청 - storyId={}, difficulty={}, language={}, count={}",
+                story.getStoryId(), difficulty, language, count);
+
+        // 동화 내용 수집
+        String storyContent = collectStoryContent(story);
+        String highlightWords = collectHighlightWords(story);
+
+        log.info("동화 내용 수집 완료 - 길이={}, 핵심단어={}", storyContent.length(), highlightWords);
+
+        // TODO: 실제 LLM API 호출
+        // String prompt = buildPrompt(story, difficulty, language, count, storyContent, highlightWords);
+        // String llmResponse = llmClient.call(prompt);
+        // return parseQuizResponse(llmResponse);
+
+        // 더미 데이터 반환 (실제 연동 전까지)
+        return generateDummyQuestions(story, difficulty, count);
+    }
+
+    // 동화 전체 텍스트 수집
+    private String collectStoryContent(Story story) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("제목: ").append(story.getTitle()).append("\n\n");
+        for (Slide slide : story.getSlides()) {
+            if (slide.getTextKr() != null) {
+                sb.append("[장면 ").append(slide.getOrder()).append("]\n");
+                sb.append(slide.getTextKr()).append("\n\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    // 핵심 단어(하이라이트) 수집
+    private String collectHighlightWords(Story story) {
+        List<String> words = new ArrayList<>();
+        for (Slide slide : story.getSlides()) {
+            slide.getTokens().stream()
+                    .filter(token -> Boolean.TRUE.equals(token.getHighlight()))
+                    .map(token -> token.getText() + "(" + token.getTranslation() + ")")
+                    .forEach(words::add);
+        }
+        return String.join(", ", words);
+    }
+
+    // 더미 퀴즈 문제 생성 (LLM 연동 전 테스트용)
+    private List<QuizQuestion> generateDummyQuestions(
+            Story story, QuizDifficulty difficulty, int count
+    ) {
+        List<QuizQuestion> questions = new ArrayList<>();
+        int vocabCount = count / 2;       // 절반은 단어 이해
+        int storyCount = count - vocabCount; // 나머지는 줄거리 이해
+
+        // 단어 이해 선다형 문제
+        for (int i = 0; i < vocabCount; i++) {
+            QuizQuestion q = QuizQuestion.builder()
+                    .questionType(QuestionType.MULTIPLE_CHOICE)
+                    .evaluationType(EvaluationType.VOCABULARY)
+                    .questionOrder(i + 1)
+                    .questionText("'" + story.getTitle() + "'에서 나온 단어의 뜻으로 올바른 것은? (문제 " + (i + 1) + ")")
+                    .correctAnswer("1")
+                    .explanation("이 단어는 동화에서 핵심적인 역할을 합니다.")
+                    .build();
+
+            q.addOption(QuizOption.builder().optionOrder(1).optionText("정답 보기").build());
+            q.addOption(QuizOption.builder().optionOrder(2).optionText("오답 보기 A").build());
+            q.addOption(QuizOption.builder().optionOrder(3).optionText("오답 보기 B").build());
+            q.addOption(QuizOption.builder().optionOrder(4).optionText("오답 보기 C").build());
+
+            questions.add(q);
+        }
+
+        // 줄거리 이해 T/F 문제
+        for (int i = 0; i < storyCount; i++) {
+            QuizQuestion q = QuizQuestion.builder()
+                    .questionType(QuestionType.TRUE_FALSE)
+                    .evaluationType(EvaluationType.STORY)
+                    .questionOrder(vocabCount + i + 1)
+                    .questionText("'" + story.getTitle() + "'에서 주인공은 모험을 떠났다. (문제 " + (vocabCount + i + 1) + ")")
+                    .correctAnswer("TRUE")
+                    .explanation("동화에서 주인공은 용기를 내어 모험을 떠납니다.")
+                    .build();
+
+            questions.add(q);
+        }
+
+        log.info("더미 퀴즈 문제 생성 완료 - 단어이해={}개, 줄거리이해={}개", vocabCount, storyCount);
+        return questions;
+    }
+}

--- a/src/main/java/com/moretale/global/exception/ErrorCode.java
+++ b/src/main/java/com/moretale/global/exception/ErrorCode.java
@@ -48,7 +48,18 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "파일을 찾을 수 없습니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F003", "파일 크기가 제한을 초과했습니다."),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 삭제에 실패했습니다.");
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 삭제에 실패했습니다."),
+
+    // 퀴즈 (Quiz)
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "퀴즈를 찾을 수 없습니다."),
+    QUIZ_ALREADY_EXISTS(HttpStatus.CONFLICT, "Q002", "이미 생성된 퀴즈가 있습니다."),
+    QUIZ_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Q003", "퀴즈 생성에 실패했습니다."),
+    QUIZ_ACCESS_DENIED(HttpStatus.FORBIDDEN, "Q004", "퀴즈에 접근할 권한이 없습니다."),
+    QUIZ_SUBMIT_INVALID(HttpStatus.BAD_REQUEST, "Q005", "퀴즈 답안이 올바르지 않습니다."),
+
+    // 꿀단지 (HoneyJar)
+    HONEY_JAR_NOT_FOUND(HttpStatus.NOT_FOUND, "H001", "꿀단지 정보를 찾을 수 없습니다."),
+    HONEY_JAR_INSUFFICIENT(HttpStatus.BAD_REQUEST, "H002", "꿀단지가 부족합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -61,6 +61,12 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/dictionary/*/bookmark").authenticated()    // 북마크 추가
                         .requestMatchers(HttpMethod.DELETE, "/api/dictionary/*/bookmark").authenticated()  // 북마크 제거
 
+                        // 퀴즈 API (인증 필요)
+                        .requestMatchers("/api/quiz/**").authenticated()
+
+                        // 꿀단지 API (인증 필요)
+                        .requestMatchers("/api/honey-jar/**").authenticated()
+
                         // ADMIN 권한 필요
                         .requestMatchers(HttpMethod.PATCH, "/api/dictionary/*/verify").hasRole("ADMIN")    // 방언 검증
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")                                 // 관리자 경로


### PR DESCRIPTION
## 📌 관련 이슈
- close #25

## ✨ 작업 내용 요약
- 꿀단지 보상 시스템 전체 구현
  - 사용자별 꿀단지 자산을 관리하는 `HoneyJar` 도메인 신규 설계 및 구현
  - 꿀단지 획득/사용 이력을 저장하는 `HoneyJarHistory` 엔티티 및 로그 구조 구축
  - 동화 완독 + 퀴즈 만점 기반 보상 시스템 구현 (동화 1권당 최대 2개 제한)
  - 꿀단지 20개 달성 시 자동 차감 및 무료 동화 생성 트리거 로직 구현
  - 비관적 락(`PESSIMISTIC_WRITE`)을 적용하여 동시성 문제 방지
- 꿀단지 API 및 조회 기능 구현
  - `GET /api/honey-jar` : 현재 보유 꿀단지 상태 조회
  - `GET /api/honey-jar/history` : 꿀단지 획득/사용 이력 조회 (최신순)
  - 최초 조회 시 꿀단지 레코드 자동 생성 로직 추가
  - 응답 DTO (`HoneyJarResponse`, `HoneyJarHistoryResponse`) 설계
- 퀴즈 시스템 전체 구현
  - 동화 1권당 1개의 퀴즈 세트를 가지는 구조로 설계
  - 퀴즈/문항/보기/결과/답안 기록까지 포함한 전체 도메인 설계
  - 퀴즈 난이도(`QuizDifficulty`)를 연령 + 언어 수준 기반으로 자동 결정
  - 4지선다형 + T/F 문제 유형 지원
  - AI 기반 퀴즈 생성 구조 인터페이스 설계 (`AIQuizService`)
- 퀴즈 API 구현
  - `GET /api/quiz?storyId=` : 퀴즈 조회 (없으면 자동 생성)
  - `POST /api/quiz/submit` : 퀴즈 제출 및 채점
  - `POST /api/quiz/story-complete` : 동화 완독 처리
- 퀴즈 채점 및 보상 로직 구현
  - 서버에서 정답 판별 및 점수 계산 (클라이언트 의존 제거)
  - 100점 달성 시 꿀단지 +1 지급
  - 오답 제출 시 보상 미지급 처리
  - 퀴즈 보상 중복 방지 (`QuizResult.honeyJarRewarded`)
  - 완독 보상 중복 방지 (`StoryReadStatus.readHoneyJarRewarded`)
  - 동화 1권당 최대 2개 보상 제한 로직 구현
- 결과 및 응답 구조 설계
  - 채점 결과 + 꿀단지 보상 정보를 함께 반환하는 `QuizResultResponse` 설계
  - 문항별 정답 여부 및 해설 포함
  - 프론트에서 바로 사용할 수 있는 결과 메시지 구성
- 보안 및 공통 설정 수정
  - `/api/quiz/**`, `/api/honey-jar/**` 인증 경로 추가
  - 퀴즈 및 꿀단지 관련 에러 코드 추가 (`ErrorCode` 확장)
- 포스트맨 테스트 완료
  - 퀴즈 생성 → 제출 → 채점 흐름
  - 퀴즈 만점 시 꿀단지 지급
  - 오답 제출 시 보상 미지급
  - 동화 완독 시 꿀단지 지급
  - 동화 1권당 보상 2개 제한
  - 중복 요청 시 보상 미지급
  - 꿀단지 20개 달성 시 자동 차감
  - `HoneyJarHistory` 정상 기록 및 조회

## 🗒️ 참고 사항
- 꿀단지 시스템은 적립 → 제한 → 자동 차감 → 이력 관리까지 포함한 완전한 보상 구조로 설계됨
- 꿀단지 이력은 감사 로그 및 향후 통계/분석 기능 확장을 고려하여 별도 테이블로 관리
- 퀴즈 생성은 현재 더미 기반이, 이후 LLM 연동 예정 (`AIQuizServiceImpl`)
- 퀴즈 응답에는 정답을 포함하지 않고 서버에서만 채점하도록 설계
  - 4/10 회의 내용에 맞춰서 피그마에 따라 정답 바로 표시되도록 수정 필요
- 동시성 문제 방지를 위해 꿀단지 차감 시 비관적 락 적용
- 모든 보상 로직은 중복 방지 + 데이터 정합성 유지를 기준으로 구현됨
- API 응답 구조는 프론트 UI에서 바로 활용 가능하도록 설계됨