### PR TITLE
Feat/14-quiz-instant-answer

### DIFF
--- a/src/main/java/com/moretale/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/moretale/domain/quiz/controller/QuizController.java
@@ -1,9 +1,7 @@
 package com.moretale.domain.quiz.controller;
 
-import com.moretale.domain.honeyjar.service.HoneyJarService;
 import com.moretale.domain.quiz.dto.*;
 import com.moretale.domain.quiz.service.QuizService;
-import com.moretale.domain.user.repository.UserRepository;
 import com.moretale.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,7 +27,9 @@ public class QuizController {
      *
      * - 동화 1권당 퀴즈 1세트 자동 생성
      * - 이미 생성된 경우 기존 퀴즈 반환
-     * - 정답은 응답에 포함되지 않음 (서버에서만 처리)
+     * - 응답에 correctAnswer, explanation 포함
+     * - 프론트에서 선택 즉시 정답/오답 피드백 처리 가능
+     * - 보상 로직은 기존과 동일하게 submit 시점에서만 실행
      */
     @Operation(
             summary = "퀴즈 조회",
@@ -37,8 +37,16 @@ public class QuizController {
                     동화에 연결된 퀴즈를 조회합니다.
                     퀴즈가 없으면 AI가 자동으로 생성합니다.
                     
-                    - 정답은 응답에 포함되지 않습니다 (채점은 서버에서 처리)
-                    - 난이도는 사용자 프로필(연령/언어수준) 기반으로 자동 결정
+                    - 각 문제에 `correctAnswer`와 `explanation`이 포함됩니다.
+                    - 프론트에서 선택지 클릭 즉시 정답(초록) / 오답(빨강 + 정답 강조) 표시 가능
+                    - 최종 채점 및 꿀단지 보상은 submit 시점에서만 처리됩니다.
+                    
+                    **correctAnswer 형식**
+                    - 선다형(MULTIPLE_CHOICE): `"1"` ~ `"4"` (선택한 보기 번호와 비교)
+                    - T/F형(TRUE_FALSE): `"TRUE"` 또는 `"FALSE"`
+                    
+                    **난이도 결정**
+                    - 사용자 프로필(연령/언어수준) 기반으로 자동 결정
                     - 문제 언어는 동화의 primaryLanguage 기준
                     """
     )
@@ -70,10 +78,16 @@ public class QuizController {
                     - 선다형: 보기 번호("1"~"4") 제출
                     - T/F형: "TRUE" 또는 "FALSE" 제출
                     - 점수 = (정답 수 / 총 문제 수) × 100
+                    - 채점은 서버에서 독립적으로 수행 (클라이언트 correctAnswer와 무관)
                     
                     **꿀단지 보상**
                     - 100점 달성 시 꿀단지 +1 (동화 1권당 최초 1회)
                     - 꿀단지 20개 달성 시 동화 1권 무료 생성 자동 처리
+                    
+                    **결과 응답 (submit 후 종합 결과 화면)**
+                    - 전체 점수, 정답 수, 100점 여부
+                    - 문항별 제출 답안 / 정답 / 정오 여부 / 해설
+                    - 꿀단지 보상 정보
                     """
     )
     @PostMapping("/submit")

--- a/src/main/java/com/moretale/domain/quiz/dto/QuizResponse.java
+++ b/src/main/java/com/moretale/domain/quiz/dto/QuizResponse.java
@@ -6,8 +6,14 @@ import lombok.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
-// GET /api/quiz?storyId={storyId} 응답 DTO
-// 정답은 포함하지 않음 (채점은 서버에서만 처리)
+/**
+ * GET /api/quiz?storyId={storyId} 응답 DTO
+ *
+ * - QuestionDto에 correctAnswer 필드 추가
+ * - 프론트에서 선택 즉시 정답/오답 판별 가능하도록 제공
+ * - 보안 trade-off: 아동 교육용 앱 특성상 클라이언트 노출 허용
+ *   서버 무결성은 submit 시점의 서버 재채점으로 보장 (기존 유지)
+ */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -46,6 +52,19 @@ public class QuizResponse {
         private String questionText;
         private List<OptionDto> options; // T/F는 빈 리스트
 
+        /**
+         * 선택 즉시 정답/오답 피드백을 위해 correctAnswer 포함
+         * - 선다형: "1" ~ "4" (보기 번호)
+         * - T/F형:  "TRUE" | "FALSE"
+         */
+        private String correctAnswer;
+
+        /**
+         * 오답 선택 시 정답 강조 표시를 위해 explanation 포함
+         * submit 이후 결과 화면에서도 동일하게 활용 가능
+         */
+        private String explanation;
+
         public static QuestionDto from(QuizQuestion question) {
             return QuestionDto.builder()
                     .questionId(question.getQuestionId())
@@ -56,6 +75,8 @@ public class QuizResponse {
                     .options(question.getOptions().stream()
                             .map(OptionDto::from)
                             .collect(Collectors.toList()))
+                    .correctAnswer(question.getCorrectAnswer())
+                    .explanation(question.getExplanation())
                     .build();
         }
     }

--- a/src/main/java/com/moretale/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/moretale/domain/quiz/service/QuizService.java
@@ -60,6 +60,8 @@ public class QuizService {
         Story story = getStoryWithAccess(user, storyId);
 
         // 기존 퀴즈가 있으면 바로 반환
+        // QuizResponse.from() 내부에서 correctAnswer, explanation 자동 포함
+        // 서비스 레이어 변경 없음 - DTO 레이어에서만 처리
         Quiz existingQuiz = quizRepository.findByStoryWithQuestions(story).orElse(null);
         if (existingQuiz != null) {
             log.info("기존 퀴즈 반환 - storyId={}, quizId={}", storyId, existingQuiz.getQuizId());


### PR DESCRIPTION
## 📌 관련 이슈
- close #29

## ✨ 작업 내용 요약
- 퀴즈 조회 API(`GET /api/quiz`) 응답에 `correctAnswer`, `explanation` 필드 추가
- 프론트에서 선택지 클릭 시 즉시 정답/오답을 판단할 수 있도록 데이터 구조 개선
- 객관식 및 T/F 문제 모두 동일한 방식으로 즉시 피드백 처리 가능하도록 통일
- Swagger 문서에 즉시 피드백 UX 관련 설명 추가
- 기존 `submit` 기반 채점 및 꿀단지 보상 로직은 변경 없이 유지

## 🗒️ 참고 사항
- 정답 정보는 클라이언트에 노출되지만 최종 채점은 서버에서 다시 수행하여 무결성 유지
- 즉시 피드백은 프론트에서 `correctAnswer` 비교로 처리, `submit` 결과와 일관성 유지됨
- 꿀단지 보상은 기존 정책과 동일하게 `submit` 시점 기준으로만 지급
- 동일 동화에 대한 퀴즈 보상은 1회로 제한되어 중복 지급 방지됨