### PR TITLE
Feat/15-mypage

### DIFF
--- a/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarHistoryRepository.java
+++ b/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarHistoryRepository.java
@@ -12,4 +12,7 @@ public interface HoneyJarHistoryRepository extends JpaRepository<HoneyJarHistory
 
     // 사용자 꿀단지 이력 조회 (최신순)
     List<HoneyJarHistory> findByUserOrderByCreatedAtDesc(User user);
+
+    // 회원 탈퇴 시 이력 삭제
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarRepository.java
+++ b/src/main/java/com/moretale/domain/honeyjar/repository/HoneyJarRepository.java
@@ -21,4 +21,7 @@ public interface HoneyJarRepository extends JpaRepository<HoneyJar, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT h FROM HoneyJar h WHERE h.user = :user")
     Optional<HoneyJar> findByUserWithLock(@Param("user") User user);
+
+    // 회원 탈퇴 시 꿀단지 삭제
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/moretale/domain/story/dto/RecentStoryResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/RecentStoryResponse.java
@@ -1,0 +1,44 @@
+package com.moretale.domain.story.dto;
+
+import com.moretale.domain.story.entity.Story;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+// 마이페이지용 최근 생성 동화 요약 응답 DTO
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentStoryResponse {
+
+    private Long storyId;
+    private String title;
+    private String childName;
+    private String primaryLanguage;
+    private String secondaryLanguage;
+
+    // 대표 썸네일 (첫 번째 슬라이드 이미지)
+    private String thumbnailUrl;
+
+    private Boolean isPublic;
+    private LocalDateTime createdAt;
+
+    public static RecentStoryResponse fromEntity(Story story) {
+        // 첫 번째 슬라이드의 이미지를 썸네일로 사용
+        String thumbnail = story.getSlides().isEmpty()
+                ? null
+                : story.getSlides().get(0).getImageUrl();
+
+        return RecentStoryResponse.builder()
+                .storyId(story.getStoryId())
+                .title(story.getTitle())
+                .childName(story.getChildName())
+                .primaryLanguage(story.getPrimaryLanguage())
+                .secondaryLanguage(story.getSecondaryLanguage())
+                .thumbnailUrl(thumbnail)
+                .isPublic(story.getIsPublic())
+                .createdAt(story.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 @Repository
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
+    // 특정 사용자의 동화 목록 조회 (최신순)
+    List<Story> findAllByUserOrderByCreatedAtDesc(User user);
+
     // 특정 사용자가 만든 동화 목록 조회 (최신순 고정 - 내부 사용)
     List<Story> findByUserOrderByCreatedAtDesc(User user);
 
@@ -32,8 +35,20 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     """)
     Optional<Story> findByIdWithSlides(@Param("storyId") Long storyId);
 
-    // 사용자별 동화 개수
+    // 마이페이지용: 최근 생성 동화 N건 조회 (슬라이드 함께 패치)
+    @Query("""
+        SELECT DISTINCT s FROM Story s
+        LEFT JOIN FETCH s.slides sl
+        WHERE s.user = :user
+        ORDER BY s.createdAt DESC
+    """)
+    List<Story> findRecentStoriesWithSlides(@Param("user") User user, Pageable pageable);
+
+    // 특정 사용자의 전체 동화 수 조회 / 사용자별 동화 개수
     long countByUser(User user);
+
+    // 특정 사용자의 모든 동화 삭제 (회원 탈퇴용)
+    void deleteAllByUser(User user);
 
     /**
      * 도서관 목록 조회 - Pageable 정렬 파라미터 지원

--- a/src/main/java/com/moretale/domain/user/controller/UserController.java
+++ b/src/main/java/com/moretale/domain/user/controller/UserController.java
@@ -1,9 +1,13 @@
 package com.moretale.domain.user.controller;
 
+import com.moretale.domain.user.dto.MyPageResponse;
+import com.moretale.domain.user.dto.RegionRequest;
 import com.moretale.domain.user.dto.UserResponse;
 import com.moretale.domain.user.service.UserService;
 import com.moretale.global.common.ApiResponse;
 import com.moretale.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +18,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 계정 관리 API")
 public class UserController {
 
     private final UserService userService;
 
     // 현재 로그인한 사용자 정보 조회
+    // GET /api/users/me
     @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 기본 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<UserResponse>> getCurrentUser(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
@@ -31,15 +38,85 @@ public class UserController {
     }
 
     // 사용자 지역 설정
+    // PATCH /api/users/me/region
     @PatchMapping("/me/region")
+    @Operation(summary = "지역 설정", description = "사용자의 지역 정보를 설정합니다.")
     public ResponseEntity<ApiResponse<UserResponse>> updateRegion(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestParam("region") String region) {
+            @RequestBody RegionRequest request) {
 
-        log.info("사용자 지역 설정 요청 - userId: {}, region: {}", userPrincipal.getUserId(), region);
-
-        UserResponse response = userService.updateRegion(userPrincipal.getUserId(), region);
-
+        log.info("사용자 지역 설정 요청 - userId: {}, region: {}", userPrincipal.getUserId(), request.getRegion());
+        UserResponse response = userService.updateRegion(userPrincipal.getUserId(), request.getRegion());
         return ResponseEntity.ok(ApiResponse.success(response, "지역이 설정되었습니다."));
+    }
+
+    // 마이페이지 통합 조회
+    /**
+     * 마이페이지 통합 조회
+     * GET /api/users/mypage
+     *
+     * <p>응답 구조:
+     * <ul>
+     *   <li>accountInfo  : 계정 정보 (이메일, 닉네임, 가입일) - read-only</li>
+     *   <li>profiles     : 자녀 프로필 목록 (온보딩 정보 포함, 수정 가능)</li>
+     *   <li>usageStatus  : 꿀단지 수 / 무료 동화 잔여 횟수 / 누적 동화 수</li>
+     *   <li>recentStories: 최근 생성 동화 5건 (썸네일 포함)</li>
+     * </ul>
+     */
+    @GetMapping("/mypage")
+    @Operation(
+            summary = "마이페이지 조회",
+            description = """
+                    사용자의 마이페이지 통합 정보를 조회합니다.
+                    
+                    **응답 구조**
+                    - `accountInfo`: 계정 정보 (Google 이메일 - read only)
+                    - `profiles`: 자녀 프로필 목록 (온보딩 정보 포함, PUT /api/users/profile/{profileId}로 수정 가능)
+                    - `usageStatus.honeyJarCount`: 현재 꿀단지 보유 수
+                    - `usageStatus.canGenerateFreeStory`: 무료 동화 생성 가능 여부
+                    - `usageStatus.remainingHoneyJarForFree`: 무료 생성까지 남은 꿀단지 수
+                    - `usageStatus.totalStoriesCreated`: 누적 생성 동화 수
+                    - `recentStories`: 최근 생성 동화 5건
+                    """
+    )
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        log.info("마이페이지 조회 요청 - userId: {}", userPrincipal.getUserId());
+        MyPageResponse response = userService.getMyPage(userPrincipal.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 회원 탈퇴
+    /**
+     * 회원 탈퇴
+     * DELETE /api/users/delete
+     *
+     * <p>처리 순서 (연관 데이터 정책):
+     * <ol>
+     *   <li>꿀단지 이력(HoneyJarHistory) 삭제</li>
+     *   <li>꿀단지(HoneyJar) 삭제</li>
+     *   <li>동화/슬라이드/토큰(Story → Slide → StoryToken) 삭제</li>
+     *   <li>자녀 프로필(UserProfile) 삭제 (User Cascade)</li>
+     *   <li>사용자(User) 삭제</li>
+     * </ol>
+     */
+    @DeleteMapping("/delete")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    현재 로그인한 사용자의 계정을 탈퇴 처리합니다.
+                    
+                    **삭제 처리 정책**
+                    - 꿀단지 이력, 꿀단지, 동화, 슬라이드, 토큰, 자녀 프로필 모두 삭제
+                    - 삭제된 데이터는 복구 불가
+                    """
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        log.info("회원 탈퇴 요청 - userId: {}", userPrincipal.getUserId());
+        userService.deleteUser(userPrincipal.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(null, "회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/src/main/java/com/moretale/domain/user/dto/AccountInfoResponse.java
+++ b/src/main/java/com/moretale/domain/user/dto/AccountInfoResponse.java
@@ -1,0 +1,43 @@
+package com.moretale.domain.user.dto;
+
+import com.moretale.domain.user.entity.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+// 계정 정보 응답 DTO (read-only)
+// Google OAuth 기반이므로 이메일 수정 불가
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountInfoResponse {
+
+    private Long userId;
+
+    // Google 이메일 (read-only)
+    private String email;
+
+    // 닉네임
+    private String nickname;
+
+    // OAuth 제공자 (google)
+    private String provider;
+
+    // 지역
+    private String region;
+
+    // 가입일
+    private LocalDateTime createdAt;
+
+    public static AccountInfoResponse fromEntity(User user) {
+        return AccountInfoResponse.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .provider(user.getProvider())
+                .region(user.getRegion())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/user/dto/MyPageResponse.java
+++ b/src/main/java/com/moretale/domain/user/dto/MyPageResponse.java
@@ -1,0 +1,34 @@
+package com.moretale.domain.user.dto;
+
+import com.moretale.domain.honeyjar.dto.HoneyJarResponse;
+import com.moretale.domain.profile.dto.UserProfileResponse;
+import com.moretale.domain.story.dto.RecentStoryResponse;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 마이페이지 통합 응답 DTO
+ * - 계정 정보 (read-only)
+ * - 자녀 프로필 목록
+ * - 사용 현황 (꿀단지, 무료 동화 잔여 횟수)
+ * - 최근 생성 동화 목록
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyPageResponse {
+
+    // 계정 정보 (Google OAuth 기반, 수정 불가)
+    private AccountInfoResponse accountInfo;
+
+    // 자녀 프로필 목록 (온보딩 기준, 수정 가능)
+    private List<UserProfileResponse> profiles;
+
+    // 사용 현황 (꿀단지 + 무료 동화 잔여 횟수)
+    private UsageStatusResponse usageStatus;
+
+    // 최근 생성 동화 목록 (최대 5건)
+    private List<RecentStoryResponse> recentStories;
+}

--- a/src/main/java/com/moretale/domain/user/dto/RegionRequest.java
+++ b/src/main/java/com/moretale/domain/user/dto/RegionRequest.java
@@ -1,0 +1,10 @@
+package com.moretale.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RegionRequest {
+    private String region;
+}

--- a/src/main/java/com/moretale/domain/user/dto/UsageStatusResponse.java
+++ b/src/main/java/com/moretale/domain/user/dto/UsageStatusResponse.java
@@ -1,0 +1,52 @@
+package com.moretale.domain.user.dto;
+
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import lombok.*;
+
+/**
+ * 사용 현황 응답 DTO
+ * - 꿀단지 보유 개수
+ * - 무료 동화 잔여 생성 가능 횟수
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UsageStatusResponse {
+
+    //현재 보유 꿀단지 수
+    private Integer honeyJarCount;
+
+    // 무료 동화 생성 가능 여부 (20개 이상)
+    private Boolean canGenerateFreeStory;
+
+    // 무료 생성까지 남은 꿀단지 수
+    private Integer remainingHoneyJarForFree;
+
+    // 누적 생성 동화 수
+    private Long totalStoriesCreated;
+
+    private static final int FREE_GENERATION_THRESHOLD = 20;
+
+    public static UsageStatusResponse of(HoneyJar honeyJar, long totalStoriesCreated) {
+        int count = honeyJar != null ? honeyJar.getCount() : 0;
+        int remaining = Math.max(0, FREE_GENERATION_THRESHOLD - count);
+
+        return UsageStatusResponse.builder()
+                .honeyJarCount(count)
+                .canGenerateFreeStory(count >= FREE_GENERATION_THRESHOLD)
+                .remainingHoneyJarForFree(remaining)
+                .totalStoriesCreated(totalStoriesCreated)
+                .build();
+    }
+
+    // 꿀단지 레코드가 아직 없는 사용자용 (신규 가입자)
+    public static UsageStatusResponse empty(long totalStoriesCreated) {
+        return UsageStatusResponse.builder()
+                .honeyJarCount(0)
+                .canGenerateFreeStory(false)
+                .remainingHoneyJarForFree(FREE_GENERATION_THRESHOLD)
+                .totalStoriesCreated(totalStoriesCreated)
+                .build();
+    }
+}

--- a/src/main/java/com/moretale/domain/user/service/UserService.java
+++ b/src/main/java/com/moretale/domain/user/service/UserService.java
@@ -1,5 +1,16 @@
 package com.moretale.domain.user.service;
 
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.honeyjar.repository.HoneyJarHistoryRepository;
+import com.moretale.domain.honeyjar.repository.HoneyJarRepository;
+import com.moretale.domain.profile.dto.UserProfileResponse;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.RecentStoryResponse;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.dto.AccountInfoResponse;
+import com.moretale.domain.user.dto.MyPageResponse;
+import com.moretale.domain.user.dto.UsageStatusResponse;
 import com.moretale.domain.user.dto.UserResponse;
 import com.moretale.domain.user.entity.User;
 import com.moretale.domain.user.repository.UserRepository;
@@ -7,8 +18,11 @@ import com.moretale.global.exception.CustomException;
 import com.moretale.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -17,29 +31,148 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final HoneyJarRepository honeyJarRepository;
+    private final HoneyJarHistoryRepository honeyJarHistoryRepository;
+    private final StoryRepository storyRepository;
 
-    // 사용자 정보 조회
+    /** 최근 동화 조회 건수 */
+    private static final int RECENT_STORY_LIMIT = 5;
+
+    // ────────────────────────────────────────────────────────────────────
+    // 기존 API
+    // ────────────────────────────────────────────────────────────────────
+
+    /** 사용자 단순 정보 조회 (기존 /me API용) */
     public UserResponse getUserInfo(Long userId) {
         log.info("사용자 정보 조회 - userId: {}", userId);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        User user = findUserById(userId);
         return UserResponse.fromEntity(user);
     }
 
-    // 사용자 지역 설정
+    /** 사용자 지역 설정 (기존 API) */
     @Transactional
     public UserResponse updateRegion(Long userId, String region) {
         log.info("사용자 지역 설정 - userId: {}, region: {}", userId, region);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        User user = findUserById(userId);
         user.setRegion(region);
-
         log.info("사용자 지역 설정 완료 - userId: {}", userId);
-
         return UserResponse.fromEntity(user);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 마이페이지 통합 조회
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * 마이페이지 통합 조회
+     * GET /api/users/mypage
+     *
+     * <p>구성:
+     * <ul>
+     *   <li>계정 정보 (read-only)</li>
+     *   <li>자녀 프로필 목록</li>
+     *   <li>사용 현황 (꿀단지 + 무료 동화 잔여 횟수 + 누적 동화 수)</li>
+     *   <li>최근 생성 동화 5건</li>
+     * </ul>
+     */
+    public MyPageResponse getMyPage(Long userId) {
+        log.info("마이페이지 조회 - userId: {}", userId);
+
+        // 1. 사용자 조회
+        User user = findUserById(userId);
+
+        // 2. 계정 정보
+        AccountInfoResponse accountInfo = AccountInfoResponse.fromEntity(user);
+
+        // 3. 자녀 프로필 목록
+        List<UserProfileResponse> profiles = userProfileRepository
+                .findAllByUser_UserId(userId)
+                .stream()
+                .map(UserProfileResponse::fromEntity)
+                .toList();
+
+        // 4. 사용 현황
+        UsageStatusResponse usageStatus = buildUsageStatus(user);
+
+        // 5. 최근 동화 5건 (슬라이드 썸네일 포함)
+        List<RecentStoryResponse> recentStories = storyRepository
+                .findRecentStoriesWithSlides(user, PageRequest.of(0, RECENT_STORY_LIMIT))
+                .stream()
+                .map(RecentStoryResponse::fromEntity)
+                .toList();
+
+        log.info("마이페이지 조회 완료 - userId: {}, 프로필 수: {}, 최근 동화 수: {}",
+                userId, profiles.size(), recentStories.size());
+
+        return MyPageResponse.builder()
+                .accountInfo(accountInfo)
+                .profiles(profiles)
+                .usageStatus(usageStatus)
+                .recentStories(recentStories)
+                .build();
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 회원 탈퇴
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * 회원 탈퇴
+     * DELETE /api/users/delete
+     *
+     * <p>연관 데이터 처리 정책:
+     * <ul>
+     *   <li>HoneyJarHistory → 먼저 삭제 (FK 제약)</li>
+     *   <li>HoneyJar → 삭제</li>
+     *   <li>Story / Slide / StoryToken → Story 삭제 시 CascadeType.ALL로 자동 처리</li>
+     *   <li>UserProfile → User CascadeType.ALL + orphanRemoval로 자동 처리</li>
+     *   <li>User → 최종 삭제</li>
+     * </ul>
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        log.info("회원 탈퇴 처리 시작 - userId: {}", userId);
+
+        User user = findUserById(userId);
+
+        // 1. 꿀단지 이력 삭제 (FK: honey_jar_histories.user_id → users.user_id)
+        honeyJarHistoryRepository.deleteAllByUser(user);
+        log.info("꿀단지 이력 삭제 완료 - userId: {}", userId);
+
+        // 2. 꿀단지 삭제 (FK: honey_jars.user_id → users.user_id)
+        honeyJarRepository.deleteByUser(user);
+        log.info("꿀단지 삭제 완료 - userId: {}", userId);
+
+        // 3. 동화 삭제
+        //    Story → Slide → StoryToken: CascadeType.ALL + orphanRemoval로 자동 처리
+        storyRepository.deleteAllByUser(user);
+        log.info("동화 데이터 삭제 완료 - userId: {}", userId);
+
+        // 4. 사용자 삭제
+        //    UserProfile: User 엔티티의 CascadeType.ALL + orphanRemoval로 자동 처리
+        userRepository.delete(user);
+        log.info("회원 탈퇴 완료 - userId: {}", userId);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // private 헬퍼
+    // ────────────────────────────────────────────────────────────────────
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 사용 현황 빌드
+     * - 꿀단지 레코드가 없는 신규 사용자는 empty() 반환
+     */
+    private UsageStatusResponse buildUsageStatus(User user) {
+        long totalStories = storyRepository.countByUser(user);
+
+        return honeyJarRepository.findByUser(user)
+                .map(honeyJar -> UsageStatusResponse.of(honeyJar, totalStories))
+                .orElseGet(() -> UsageStatusResponse.empty(totalStories));
     }
 }

--- a/src/main/java/com/moretale/global/exception/ErrorCode.java
+++ b/src/main/java/com/moretale/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     // 사용자 (User)
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "U003", "이미 탈퇴된 사용자입니다."),
 
     // 프로필 (Profile)
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로필을 찾을 수 없습니다."),

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -67,6 +67,10 @@ public class SecurityConfig {
                         // 꿀단지 API (인증 필요)
                         .requestMatchers("/api/honey-jar/**").authenticated()
 
+                        // 마이페이지 & 회원 탈퇴 (인증 필요)
+                        .requestMatchers(HttpMethod.GET, "/api/users/mypage").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/users/delete").authenticated()
+
                         // ADMIN 권한 필요
                         .requestMatchers(HttpMethod.PATCH, "/api/dictionary/*/verify").hasRole("ADMIN")    // 방언 검증
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")                                 // 관리자 경로


### PR DESCRIPTION
## 📌 관련 이슈
- close #27

## ✨ 작업 내용 요약
- 마이페이지 조회 및 사용자 상태 관리 기능 구현
- 마이페이지 통합 응답 구조 설계 및 `GET /api/users/mypage` API 구현 (`accountInfo` / `profiles` / `usageStatus` / `recentStories`)
- 계정 정보에 `region` 필드 추가 및 지역 설정 API 개선 (`RequestParam` → `RequestBody` 기반 DTO 적용)
- 사용 현황(`usageStatus`) 구조 설계 (꿀단지 수, 무료 생성 가능 여부, 남은 개수, 누적 동화 수)
- 최근 생성 동화 조회 기능 추가 (최대 5건, 첫 번째 슬라이드(표지)를 썸네일로 사용)
- `Story` / `HoneyJar` Repository 확장 (동화 수 조회, 최근 동화 조회, 회원 탈퇴 시 연관 데이터 삭제)
- 회원 탈퇴 API 구현 및 연관 데이터 삭제 정책 반영
- `ErrorCode` 및 `SecurityConfig` 수정 (사용자 탈퇴 예외 코드, 마이페이지/탈퇴 API 인증 설정 추가)\
- 동화 저장 이후 마이페이지 연동 검증 완료 (`recentStories` 반영, `totalStoriesCreated` 증가 확인)

## 🗒️ 참고 사항
- 마이페이지는 '조회 중심 + 일부 수정 기능' 구조로 설계됨 (계정 정보 read-only, 프로필은 별도 API로 수정)
- 동화 생성 시점이 아닌 동화 저장 시점 기준으로 `recentStories` 및 `totalStoriesCreated`가 반영됨
- 꿀단지 보상 정책은 다음 기준으로 동작함
  - 동화 생성 → 보상 없음
  - 동화 완독 → +1
  - 퀴즈 100점 → +1
  - 동화 1권당 최대 2개 지급
- 따라서 마이페이지 조회 시 `honeyJarCount`, `canGenerateFreeStory`, `remainingHoneyJarForFree` 값이 즉시 변경되지 않는 것은 정상 동작
- 회원 탈퇴 API는 구현 완료되었으나 실제 삭제 흐름 테스트는 추후 진행 예정
- 마이페이지 응답 구조는 프론트 UI에서 바로 사용할 수 있도록 설계됨 (썸네일, 언어 정보, 사용 현황 포함)