### PR TITLE
Feat/16-onboarding-language-enum

### DIFF
--- a/src/main/java/com/moretale/domain/profile/dto/LanguageUpdateRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/LanguageUpdateRequest.java
@@ -1,21 +1,50 @@
 package com.moretale.domain.profile.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import com.moretale.domain.profile.entity.Language;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
+/**
+ * 언어 설정 단독 수정 요청 DTO
+ *
+ * 기존 String 패턴 → Language Enum으로 변경
+ * Legacy primaryLanguage/secondaryLanguage는 Service에서 자동 동기화
+ */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "언어 설정 수정 요청 DTO")
 public class LanguageUpdateRequest {
 
-    @NotBlank(message = "기본 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (예: ko, en)")
-    private String primaryLanguage;
+    @NotNull(message = "첫 번째 언어는 필수입니다.")
+    @Schema(description = "첫 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "KO")
+    private Language firstLanguage;
 
-    @NotBlank(message = "부모 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (예: vi, en)")
-    private String secondaryLanguage;
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "첫 번째 언어 직접 입력 (OTHER 시 필수)", example = "태국어")
+    private String customFirstLanguage;
+
+    @NotNull(message = "두 번째 언어는 필수입니다.")
+    @Schema(description = "두 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "VI")
+    private Language secondLanguage;
+
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "두 번째 언어 직접 입력 (OTHER 시 필수)")
+    private String customSecondLanguage;
+
+    // OTHER 선택 시 custom 값 검증
+    public void validate() {
+        if (Language.OTHER.equals(firstLanguage) &&
+                (customFirstLanguage == null || customFirstLanguage.isBlank())) {
+            throw new IllegalArgumentException("'기타' 선택 시 첫 번째 언어를 직접 입력해주세요.");
+        }
+        if (Language.OTHER.equals(secondLanguage) &&
+                (customSecondLanguage == null || customSecondLanguage.isBlank())) {
+            throw new IllegalArgumentException("'기타' 선택 시 두 번째 언어를 직접 입력해주세요.");
+        }
+    }
 }

--- a/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileRequest.java
@@ -1,68 +1,122 @@
 package com.moretale.domain.profile.dto;
 
-import com.moretale.domain.profile.entity.AgeGroup;
-import com.moretale.domain.profile.entity.FamilyStructure;
-import com.moretale.domain.profile.entity.LanguageProficiency;
-import com.moretale.domain.profile.entity.StoryPreference;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.global.validation.LanguageValidatable;
+import com.moretale.global.validation.ValidLanguageInput;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
+/**
+ * 온보딩 프로필 생성 요청 DTO
+ *
+ * [언어 입력 구조]
+ * - firstLanguage  : Language Enum (KO/EN/JA/ZH/ES/VI/OTHER)
+ * - customFirst..  : OTHER 선택 시 필수, 그 외 무시
+ *
+ * [요청 예시 - 일반 언어 선택]
+ * {
+ *   "firstLanguage": "KO",
+ *   "secondLanguage": "VI",
+ *   ...
+ * }
+ *
+ * [요청 예시 - 기타 언어 직접 입력]
+ * {
+ *   "firstLanguage": "OTHER",
+ *   "customFirstLanguage": "태국어",
+ *   "secondLanguage": "EN",
+ *   ...
+ * }
+ */
+@ValidLanguageInput  // Cross-field validation (언어 + custom 조합 검증)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class OnboardingProfileRequest {
+@Schema(description = "온보딩 프로필 생성 요청 DTO")
+public class OnboardingProfileRequest implements LanguageValidatable {
 
     // 1단계: 주인공(아이) 소개
     @NotBlank(message = "아이 이름은 필수입니다.")
     @Size(max = 50, message = "아이 이름은 50자 이하여야 합니다.")
+    @Schema(description = "아이 이름", example = "민준")
     private String childName;
 
-    @NotNull(message = "아이 나이는 필수입니다.")
-    private AgeGroup ageGroup; // 0-2세, 3-4세, 5-6세, 7-8세, 9-10세, 10세이상
+    @NotNull(message = "아이 나이 그룹은 필수입니다.")
+    @Schema(description = "나이 그룹 (AGE_0_2 / AGE_3_4 / AGE_5_6 / AGE_7_8 / AGE_9_10 / AGE_10_PLUS)",
+            example = "AGE_5_6")
+    private AgeGroup ageGroup;
 
-    // 2단계: 주인공이 쓰는 말이에요
-    @NotBlank(message = "첫 번째 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다 (ex. ko, en)")
-    private String firstLanguage; // 첫 번째 말 (주 사용 언어)
+    // 2단계: 주인공이 쓰는 말 (언어 선택)
+    @NotNull(message = "첫 번째 언어는 필수입니다.")
+    @Schema(description = "첫 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "KO")
+    private Language firstLanguage;
 
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "첫 번째 언어 직접 입력 (firstLanguage=OTHER 시 필수)", example = "태국어")
+    private String customFirstLanguage;
+
+    @NotNull(message = "두 번째 언어는 필수입니다.")
+    @Schema(description = "두 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "VI")
+    private Language secondLanguage;
+
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "두 번째 언어 직접 입력 (secondLanguage=OTHER 시 필수)", example = "힌디어")
+    private String customSecondLanguage;
+
+    // 3단계: 언어 숙련도
     @NotNull(message = "첫 번째 언어 숙련도는 필수입니다.")
-    private LanguageProficiency firstLanguageProficiency; // 알, 애벌레, 번데기, 꿀벌
-
-    @NotBlank(message = "두 번째 언어는 필수입니다.")
-    @Pattern(regexp = "^[a-z]{2}$", message = "언어 코드는 2자리 소문자여야 합니다")
-    private String secondLanguage; // 두 번째 말
+    @Schema(description = "첫 번째 언어 전체 숙련도 (EGG/LARVA/PUPA/BEE)", example = "BEE")
+    private LanguageProficiency firstLanguageProficiency;
 
     @NotNull(message = "두 번째 언어 숙련도는 필수입니다.")
+    @Schema(description = "두 번째 언어 전체 숙련도 (EGG/LARVA/PUPA/BEE)", example = "LARVA")
     private LanguageProficiency secondLanguageProficiency;
 
-    // 3단계: 이 언어로 어느 정도 말할 수 있나요?
     @NotNull(message = "첫 번째 언어 듣기 숙련도는 필수입니다.")
+    @Schema(description = "첫 번째 언어 듣기 능력 (EGG/LARVA/PUPA/BEE)", example = "BEE")
     private LanguageProficiency firstLanguageListening;
 
     @NotNull(message = "첫 번째 언어 말하기 숙련도는 필수입니다.")
+    @Schema(description = "첫 번째 언어 말하기 능력 (EGG/LARVA/PUPA/BEE)", example = "PUPA")
     private LanguageProficiency firstLanguageSpeaking;
 
     @NotNull(message = "두 번째 언어 듣기 숙련도는 필수입니다.")
+    @Schema(description = "두 번째 언어 듣기 능력 (EGG/LARVA/PUPA/BEE)", example = "LARVA")
     private LanguageProficiency secondLanguageListening;
 
     @NotNull(message = "두 번째 언어 말하기 숙련도는 필수입니다.")
+    @Schema(description = "두 번째 언어 말하기 능력 (EGG/LARVA/PUPA/BEE)", example = "EGG")
     private LanguageProficiency secondLanguageSpeaking;
 
     // 4단계: 함께 사는 사람들
     @NotNull(message = "함께 사는 사람 정보는 필수입니다.")
-    private FamilyStructure familyStructure; // 한 분과 살아요, 두 분과 살아요, 다른 가족과 살아요, 비밀이에요, 직접 작성
+    @Schema(description = "가족 구조 (ONE_PARENT/TWO_PARENTS/EXTENDED_FAMILY/SECRET/CUSTOM)",
+            example = "TWO_PARENTS")
+    private FamilyStructure familyStructure;
 
-    private String customFamilyStructure; // 직접 작성 시 사용
+    @Size(max = 200, message = "가족 구조 직접 입력은 200자 이하여야 합니다.")
+    @Schema(description = "가족 구조 직접 입력 (familyStructure=CUSTOM 시 필수)", example = "조부모님과 살아요")
+    private String customFamilyStructure;
 
     // 5단계: 어떤 이야기가 좋아요
-    @NotNull(message = "선호하는 이야기 유형은 필수입니다.")
-    private StoryPreference storyPreference; // 포근포근한 이야기, 신나는 모험 이야기, 오늘 하루를 담은 이야기, 직접 작성
+    @NotNull(message = "선호 이야기 유형은 필수입니다.")
+    @Schema(description = "이야기 선호도 (WARM_HUG/FUN_ADVENTURE/DAILY_LIFE/CUSTOM)",
+            example = "FUN_ADVENTURE")
+    private StoryPreference storyPreference;
 
-    private String customStoryPreference; // 직접 작성 시 사용
+    @Size(max = 200, message = "이야기 선호도 직접 입력은 200자 이하여야 합니다.")
+    @Schema(description = "이야기 선호도 직접 입력 (storyPreference=CUSTOM 시 필수)", example = "우주 탐험 이야기")
+    private String customStoryPreference;
 
     // 부가 정보 (선택)
+    @Size(max = 50, message = "아이 국적은 50자 이하여야 합니다.")
+    @Schema(description = "아이 국적 (ISO 3166-1 alpha-2)", example = "KR")
     private String childNationality;
+
+    @Size(max = 50, message = "부모 거주 국가는 50자 이하여야 합니다.")
+    @Schema(description = "부모 거주 국가 (ISO 3166-1 alpha-2)", example = "VN")
     private String parentCountry;
 }

--- a/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileResponse.java
+++ b/src/main/java/com/moretale/domain/profile/dto/OnboardingProfileResponse.java
@@ -1,10 +1,7 @@
 package com.moretale.domain.profile.dto;
 
-import com.moretale.domain.profile.entity.AgeGroup;
-import com.moretale.domain.profile.entity.FamilyStructure;
-import com.moretale.domain.profile.entity.LanguageProficiency;
-import com.moretale.domain.profile.entity.StoryPreference;
-import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.entity.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,6 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "온보딩 프로필 생성 응답 DTO")
 public class OnboardingProfileResponse {
 
     private Long profileId;
@@ -21,15 +19,30 @@ public class OnboardingProfileResponse {
     private String nickname;
     private String childName;
     private AgeGroup ageGroup;
-    private Integer childAge; // 실제 나이 (대표값)
+    private Integer childAge;
 
-    // 언어 설정
-    private String firstLanguage;
+    // 언어 (Enum + Custom + Display)
+    @Schema(description = "첫 번째 언어 Enum", example = "KO")
+    private Language firstLanguage;
+
+    @Schema(description = "첫 번째 언어 직접 입력값 (OTHER 시)", example = "태국어")
+    private String customFirstLanguage;
+
+    @Schema(description = "첫 번째 언어 표시명", example = "한국어")
+    private String firstLanguageDisplay;
+
+    @Schema(description = "두 번째 언어 Enum", example = "VI")
+    private Language secondLanguage;
+
+    @Schema(description = "두 번째 언어 직접 입력값 (OTHER 시)")
+    private String customSecondLanguage;
+
+    @Schema(description = "두 번째 언어 표시명", example = "베트남어")
+    private String secondLanguageDisplay;
+
+    // 숙련도
     private LanguageProficiency firstLanguageProficiency;
-    private String secondLanguage;
     private LanguageProficiency secondLanguageProficiency;
-
-    // 언어 능력 (듣기/말하기)
     private LanguageProficiency firstLanguageListening;
     private LanguageProficiency firstLanguageSpeaking;
     private LanguageProficiency secondLanguageListening;
@@ -63,18 +76,26 @@ public class OnboardingProfileResponse {
                 .childName(profile.getChildName())
                 .ageGroup(profile.getAgeGroup())
                 .childAge(profile.getChildAge())
+                // 언어 Enum + Custom + Display
                 .firstLanguage(profile.getFirstLanguage())
-                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
+                .customFirstLanguage(profile.getCustomFirstLanguage())
+                .firstLanguageDisplay(profile.getFirstLanguageDisplay())
                 .secondLanguage(profile.getSecondLanguage())
+                .customSecondLanguage(profile.getCustomSecondLanguage())
+                .secondLanguageDisplay(profile.getSecondLanguageDisplay())
+                // 숙련도
+                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
                 .secondLanguageProficiency(profile.getSecondLanguageProficiency())
                 .firstLanguageListening(profile.getFirstLanguageListening())
                 .firstLanguageSpeaking(profile.getFirstLanguageSpeaking())
                 .secondLanguageListening(profile.getSecondLanguageListening())
                 .secondLanguageSpeaking(profile.getSecondLanguageSpeaking())
+                // 가족/이야기
                 .familyStructure(profile.getFamilyStructure())
                 .customFamilyStructure(profile.getCustomFamilyStructure())
                 .storyPreference(profile.getStoryPreference())
                 .customStoryPreference(profile.getCustomStoryPreference())
+                // 부가
                 .childNationality(profile.getChildNationality())
                 .parentCountry(profile.getParentCountry())
                 .createdAt(profile.getCreatedAt())

--- a/src/main/java/com/moretale/domain/profile/dto/UserProfileRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/UserProfileRequest.java
@@ -1,20 +1,22 @@
 package com.moretale.domain.profile.dto;
 
-import com.moretale.domain.profile.entity.AgeGroup;
-import com.moretale.domain.profile.entity.FamilyStructure;
-import com.moretale.domain.profile.entity.LanguageProficiency;
-import com.moretale.domain.profile.entity.StoryPreference;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.global.validation.LanguageValidatable;
+import com.moretale.global.validation.ValidLanguageInput;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
+// 사용자 프로필 생성/수정 요청 DTO (일반 API용)
+// OnboardingProfileRequest와 동일한 언어 입력 구조 적용
+@ValidLanguageInput
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Schema(description = "사용자 프로필 요청 DTO (생성/수정)")
-public class UserProfileRequest {
+public class UserProfileRequest implements LanguageValidatable {
 
     @NotBlank(message = "아이 이름은 필수입니다.")
     @Size(max = 50, message = "아이 이름은 50자 이하로 입력해주세요.")
@@ -22,23 +24,33 @@ public class UserProfileRequest {
     private String childName;
 
     @NotNull(message = "나이 그룹은 필수입니다.")
-    @Schema(description = "나이 그룹 (AGE_0_2, AGE_3_4, AGE_5_6, AGE_7_8, AGE_9_10, AGE_10_PLUS)", example = "AGE_5_6")
+    @Schema(description = "나이 그룹", example = "AGE_5_6")
     private AgeGroup ageGroup;
 
-    @NotBlank(message = "제1언어는 필수입니다.")
-    @Schema(description = "제1언어 (ISO 639-1 코드)", example = "ko")
-    private String firstLanguage;
+    // 언어 (Enum + Custom)
+    @NotNull(message = "제1언어는 필수입니다.")
+    @Schema(description = "제1언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "KO")
+    private Language firstLanguage;
 
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "제1언어 직접 입력 (OTHER 선택 시 필수)", example = "태국어")
+    private String customFirstLanguage;
+
+    @NotNull(message = "제2언어는 필수입니다.")
+    @Schema(description = "제2언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "VI")
+    private Language secondLanguage;
+
+    @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
+    @Schema(description = "제2언어 직접 입력 (OTHER 선택 시 필수)")
+    private String customSecondLanguage;
+
+    // 숙련도
     @NotNull(message = "제1언어 숙련도는 필수입니다.")
-    @Schema(description = "제1언어 전체 숙련도 (EGG, LARVA, PUPA, BEE)", example = "BEE")
+    @Schema(description = "제1언어 전체 숙련도 (EGG/LARVA/PUPA/BEE)", example = "BEE")
     private LanguageProficiency firstLanguageProficiency;
 
-    @NotBlank(message = "제2언어는 필수입니다.")
-    @Schema(description = "제2언어 (ISO 639-1 코드)", example = "vi")
-    private String secondLanguage;
-
     @NotNull(message = "제2언어 숙련도는 필수입니다.")
-    @Schema(description = "제2언어 전체 숙련도 (EGG, LARVA, PUPA, BEE)", example = "LARVA")
+    @Schema(description = "제2언어 전체 숙련도", example = "LARVA")
     private LanguageProficiency secondLanguageProficiency;
 
     @NotNull(message = "제1언어 듣기 능력은 필수입니다.")
@@ -57,41 +69,45 @@ public class UserProfileRequest {
     @Schema(description = "제2언어 말하기 능력", example = "LARVA")
     private LanguageProficiency secondLanguageSpeaking;
 
+    // 가족 구조
     @NotNull(message = "가족 구조는 필수입니다.")
-    @Schema(description = "가족 구조 (ONE_PARENT, TWO_PARENTS, EXTENDED_FAMILY, SECRET, CUSTOM)", example = "TWO_PARENTS")
+    @Schema(description = "가족 구조 (ONE_PARENT/TWO_PARENTS/EXTENDED_FAMILY/SECRET/CUSTOM)",
+            example = "TWO_PARENTS")
     private FamilyStructure familyStructure;
 
     @Size(max = 200, message = "커스텀 가족 구조는 200자 이하로 입력해주세요.")
-    @Schema(description = "커스텀 가족 구조 (CUSTOM 선택 시)")
+    @Schema(description = "커스텀 가족 구조 (CUSTOM 선택 시 필수)")
     private String customFamilyStructure;
 
+    // 이야기 선호도
     @NotNull(message = "이야기 선호도는 필수입니다.")
-    @Schema(description = "이야기 선호도 (WARM_HUG, FUN_ADVENTURE, DAILY_LIFE, CUSTOM)", example = "FUN_ADVENTURE")
+    @Schema(description = "이야기 선호도 (WARM_HUG/FUN_ADVENTURE/DAILY_LIFE/CUSTOM)",
+            example = "FUN_ADVENTURE")
     private StoryPreference storyPreference;
 
     @Size(max = 200, message = "커스텀 이야기 선호도는 200자 이하로 입력해주세요.")
-    @Schema(description = "커스텀 이야기 선호도 (CUSTOM 선택 시)")
+    @Schema(description = "커스텀 이야기 선호도 (CUSTOM 선택 시 필수)")
     private String customStoryPreference;
 
-    @Size(max = 50, message = "아이 국적은 50자 이하로 입력해주세요.")
-    @Schema(description = "아이 국적 (ISO 3166-1 alpha-2)", example = "KR")
+    // 부가 정보
+    @Size(max = 50)
+    @Schema(description = "아이 국적", example = "KR")
     private String childNationality;
 
-    @Size(max = 50, message = "부모 거주 국가는 50자 이하로 입력해주세요.")
-    @Schema(description = "부모 거주 국가 (ISO 3166-1 alpha-2)", example = "VN")
+    @Size(max = 50)
+    @Schema(description = "부모 거주 국가", example = "VN")
     private String parentCountry;
 
+    // Deprecated
     @Deprecated
-    @Schema(description = "[Deprecated] 기본 언어", example = "ko")
+    @Schema(description = "[Deprecated] 사용 안 함 - firstLanguage로 대체")
     private String primaryLanguage;
 
     @Deprecated
-    @Schema(description = "[Deprecated] 보조 언어", example = "vi")
+    @Schema(description = "[Deprecated] 사용 안 함 - secondLanguage로 대체")
     private String secondaryLanguage;
 
     @Deprecated
-    @Min(value = 1, message = "아이 나이는 1세 이상이어야 합니다.")
-    @Max(value = 12, message = "아이 나이는 12세 이하여야 합니다.")
-    @Schema(description = "[Deprecated] 아이 나이", example = "6")
+    @Schema(description = "[Deprecated] ageGroup으로 자동 계산됨")
     private Integer childAge;
 }

--- a/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
+++ b/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
@@ -2,10 +2,16 @@ package com.moretale.domain.profile.dto;
 
 import com.moretale.domain.profile.entity.AgeGroup;
 import com.moretale.domain.profile.entity.FamilyStructure;
+import com.moretale.domain.profile.entity.Language;
 import com.moretale.domain.profile.entity.LanguageProficiency;
 import com.moretale.domain.profile.entity.StoryPreference;
 import com.moretale.domain.profile.entity.UserProfile;
-import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +20,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "사용자 프로필 응답 DTO")
 public class UserProfileResponse {
 
     private Long profileId;
@@ -21,17 +28,20 @@ public class UserProfileResponse {
     private String nickname;
     private String childName;
     private Integer childAge;
-
-    // 온보딩 상세 필드 추가
     private AgeGroup ageGroup;
 
-    // 언어 설정
-    private String firstLanguage;
-    private LanguageProficiency firstLanguageProficiency;
-    private String secondLanguage;
-    private LanguageProficiency secondLanguageProficiency;
+    // 언어 (Enum + Custom + Display)
+    private Language firstLanguage;
+    private String customFirstLanguage;
+    private String firstLanguageDisplay;
 
-    // 언어 능력 (듣기/말하기)
+    private Language secondLanguage;
+    private String customSecondLanguage;
+    private String secondLanguageDisplay;
+
+    // 숙련도
+    private LanguageProficiency firstLanguageProficiency;
+    private LanguageProficiency secondLanguageProficiency;
     private LanguageProficiency firstLanguageListening;
     private LanguageProficiency firstLanguageSpeaking;
     private LanguageProficiency secondLanguageListening;
@@ -45,15 +55,9 @@ public class UserProfileResponse {
     private StoryPreference storyPreference;
     private String customStoryPreference;
 
+    // 부가 정보
     private String childNationality;
     private String parentCountry;
-
-    // 하위 호환성 필드 (Deprecated)
-    @Deprecated
-    private String primaryLanguage;
-
-    @Deprecated
-    private String secondaryLanguage;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -70,22 +74,33 @@ public class UserProfileResponse {
                 .childName(profile.getChildName())
                 .childAge(profile.getChildAge())
                 .ageGroup(profile.getAgeGroup())
+
+                // 언어
                 .firstLanguage(profile.getFirstLanguage())
-                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
+                .customFirstLanguage(profile.getCustomFirstLanguage())
+                .firstLanguageDisplay(profile.getFirstLanguageDisplay())
                 .secondLanguage(profile.getSecondLanguage())
+                .customSecondLanguage(profile.getCustomSecondLanguage())
+                .secondLanguageDisplay(profile.getSecondLanguageDisplay())
+
+                // 숙련도
+                .firstLanguageProficiency(profile.getFirstLanguageProficiency())
                 .secondLanguageProficiency(profile.getSecondLanguageProficiency())
                 .firstLanguageListening(profile.getFirstLanguageListening())
                 .firstLanguageSpeaking(profile.getFirstLanguageSpeaking())
                 .secondLanguageListening(profile.getSecondLanguageListening())
                 .secondLanguageSpeaking(profile.getSecondLanguageSpeaking())
+
+                // 가족/이야기
                 .familyStructure(profile.getFamilyStructure())
                 .customFamilyStructure(profile.getCustomFamilyStructure())
                 .storyPreference(profile.getStoryPreference())
                 .customStoryPreference(profile.getCustomStoryPreference())
+
+                // 부가 정보
                 .childNationality(profile.getChildNationality())
                 .parentCountry(profile.getParentCountry())
-                .primaryLanguage(profile.getPrimaryLanguage())
-                .secondaryLanguage(profile.getSecondaryLanguage())
+
                 .createdAt(profile.getCreatedAt())
                 .updatedAt(profile.getUpdatedAt())
                 .build();

--- a/src/main/java/com/moretale/domain/profile/entity/Language.java
+++ b/src/main/java/com/moretale/domain/profile/entity/Language.java
@@ -1,0 +1,51 @@
+package com.moretale.domain.profile.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 지원 언어 Enum
+ * - KO ~ VI : 사전 정의된 언어 (UI 버튼 선택)
+ * - OTHER   : 기타 (사용자 직접 입력 → customFirstLanguage / customSecondLanguage 사용)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Language {
+
+    KO("한국어", "ko"),
+    EN("영어", "en"),
+    JA("일본어", "ja"),
+    ZH("중국어", "zh"),
+    ES("스페인어", "es"),
+    VI("베트남어", "vi"),
+    OTHER("기타", null); // 직접 입력
+
+    private final String description; // UI 표시명
+    private final String isoCode;     // ISO 639-1 코드 (OTHER는 null)
+
+    /**
+     * 하위 호환성: 기존 String 코드 → Language Enum 변환
+     * ex) "ko" → KO, "vi" → VI, 매핑 불가 시 OTHER 반환
+     */
+    public static Language fromIsoCode(String isoCode) {
+        if (isoCode == null) return OTHER;
+        for (Language lang : values()) {
+            if (isoCode.equalsIgnoreCase(lang.isoCode)) {
+                return lang;
+            }
+        }
+        return OTHER;
+    }
+
+    /**
+     * primary/secondary 동기화용: 실제 저장할 언어 코드 문자열 반환
+     * - OTHER면 customValue(직접 입력값)를 반환
+     * - 그 외에는 name() 반환 (ex. "KO", "EN")
+     */
+    public String resolveCode(String customValue) {
+        if (this == OTHER) {
+            return customValue != null ? customValue : "OTHER";
+        }
+        return this.name();
+    }
+}

--- a/src/main/java/com/moretale/domain/profile/entity/UserProfile.java
+++ b/src/main/java/com/moretale/domain/profile/entity/UserProfile.java
@@ -8,8 +8,16 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
-// 자녀 프로필 정보 엔티티
-// 한 명의 사용자가 여러 명의 자녀를 가질 수 있다.
+/**
+ * 자녀 프로필 정보 엔티티
+ * 한 명의 사용자(부모)가 여러 명의 자녀를 가질 수 있다.
+ *
+ * [언어 필드 구조]
+ * - firstLanguage / secondLanguage       : Enum (Source of Truth)
+ * - customFirstLanguage / customSecond.. : OTHER 선택 시 직접 입력값
+ * - primaryLanguage / secondaryLanguage  : @Deprecated Legacy 호환용 파생값
+ *   → syncLegacyLanguages() 호출 시 자동 동기화
+ */
 @Entity
 @Table(name = "user_profiles")
 @Getter
@@ -31,7 +39,7 @@ public class UserProfile {
     @Column(name = "child_name", nullable = false, length = 50)
     private String childName;
 
-    // 나이 그룹 (Enum)
+    // 나이
     @Enumerated(EnumType.STRING)
     @Column(name = "age_group", nullable = false)
     private AgeGroup ageGroup;
@@ -40,16 +48,33 @@ public class UserProfile {
     @Column(name = "child_age", nullable = false)
     private Integer childAge;
 
-    // 언어 설정
-    @Column(name = "first_language", nullable = false, length = 10)
-    private String firstLanguage;
+    // 언어 (Enum + Custom)
+    /**
+     * 첫 번째 언어 Enum (Source of Truth)
+     * OTHER 선택 시 customFirstLanguage에 실제 언어명 저장
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "first_language_enum", nullable = false, length = 10)
+    private Language firstLanguage;
 
+    @Column(name = "custom_first_language", length = 100)
+    private String customFirstLanguage;
+
+    /**
+     * 두 번째 언어 Enum (Source of Truth)
+     * OTHER 선택 시 customSecondLanguage에 실제 언어명 저장
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "second_language_enum", nullable = false, length = 10)
+    private Language secondLanguage;
+
+    @Column(name = "custom_second_language", length = 100)
+    private String customSecondLanguage;
+
+    // 언어 숙련도
     @Enumerated(EnumType.STRING)
     @Column(name = "first_language_proficiency", nullable = false)
     private LanguageProficiency firstLanguageProficiency;
-
-    @Column(name = "second_language", nullable = false, length = 10)
-    private String secondLanguage;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "second_language_proficiency", nullable = false)
@@ -88,22 +113,31 @@ public class UserProfile {
     @Column(name = "custom_story_preference", length = 200)
     private String customStoryPreference;
 
-    // 부가 정보 (선택)
+    // 부가 정보
     @Column(name = "child_nationality", length = 50)
     private String childNationality;
 
     @Column(name = "parent_country", length = 50)
     private String parentCountry;
 
-    // 하위 호환성 유지 (기존 필드)
+    // Legacy 호환 필드 (@Deprecated)
+    /**
+     * @deprecated firstLanguage(Enum) 기반으로 syncLegacyLanguages() 통해 자동 동기화.
+     *             StoryService, TTS, Quiz 등 기존 참조 로직 유지용.
+     *             향후 제거 예정.
+     */
     @Deprecated
-    @Column(name = "primary_language", length = 10)
+    @Column(name = "primary_language", length = 100)
     private String primaryLanguage;
 
+    /**
+     * @deprecated secondLanguage(Enum) 기반으로 syncLegacyLanguages() 통해 자동 동기화.
+     */
     @Deprecated
-    @Column(name = "secondary_language", length = 10)
+    @Column(name = "secondary_language", length = 100)
     private String secondaryLanguage;
 
+    // 타임스탬프
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -114,13 +148,62 @@ public class UserProfile {
 
     // 비즈니스 로직
 
-    // 프로필 업데이트
+    // 나이 그룹에서 실제 나이 자동 계산
+    @PrePersist
+    @PreUpdate
+    public void calculateChildAge() {
+        if (this.ageGroup != null) {
+            this.childAge = this.ageGroup.getRepresentativeAge();
+        }
+        // 저장/수정 시 항상 Legacy 필드 동기화
+        syncLegacyLanguages();
+    }
+
+    /**
+     * Legacy 호환: primaryLanguage / secondaryLanguage 자동 동기화
+     *
+     * - OTHER인 경우: customXxxLanguage 값으로 동기화
+     * - 일반 Enum:   Enum name() 값으로 동기화 (ex. "KO", "EN")
+     *
+     * StoryService, TTS, Quiz 등 기존 서비스는 primary/secondary를 그대로 참조하면 됨.
+     */
+    public void syncLegacyLanguages() {
+        if (this.firstLanguage != null) {
+            this.primaryLanguage = this.firstLanguage.resolveCode(this.customFirstLanguage);
+        }
+        if (this.secondLanguage != null) {
+            this.secondaryLanguage = this.secondLanguage.resolveCode(this.customSecondLanguage);
+        }
+    }
+
+    /**
+     * 첫 번째 언어 표시명 반환 (UI/로그용)
+     * ex) KO → "한국어", OTHER + customValue → "태국어"
+     */
+    public String getFirstLanguageDisplay() {
+        if (this.firstLanguage == Language.OTHER) {
+            return this.customFirstLanguage != null ? this.customFirstLanguage : "기타";
+        }
+        return this.firstLanguage != null ? this.firstLanguage.getDescription() : null;
+    }
+
+    // 두 번째 언어 표시명 반환 (UI/로그용)
+    public String getSecondLanguageDisplay() {
+        if (this.secondLanguage == Language.OTHER) {
+            return this.customSecondLanguage != null ? this.customSecondLanguage : "기타";
+        }
+        return this.secondLanguage != null ? this.secondLanguage.getDescription() : null;
+    }
+
+    // 프로필 전체 업데이트
     public void updateProfile(
             String childName,
             AgeGroup ageGroup,
-            String firstLanguage,
+            Language firstLanguage,
+            String customFirstLanguage,
             LanguageProficiency firstLanguageProficiency,
-            String secondLanguage,
+            Language secondLanguage,
+            String customSecondLanguage,
             LanguageProficiency secondLanguageProficiency,
             LanguageProficiency firstLanguageListening,
             LanguageProficiency firstLanguageSpeaking,
@@ -137,18 +220,29 @@ public class UserProfile {
         this.ageGroup = ageGroup;
         // 나이 그룹의 대표값으로 childAge 갱신
         this.childAge = ageGroup.getRepresentativeAge();
+
         this.firstLanguage = firstLanguage;
+        // OTHER가 아닌 경우 customFirstLanguage는 null 처리
+        this.customFirstLanguage = (firstLanguage == Language.OTHER) ? customFirstLanguage : null;
+
         this.firstLanguageProficiency = firstLanguageProficiency;
+
         this.secondLanguage = secondLanguage;
+        this.customSecondLanguage = (secondLanguage == Language.OTHER) ? customSecondLanguage : null;
+
         this.secondLanguageProficiency = secondLanguageProficiency;
         this.firstLanguageListening = firstLanguageListening;
         this.firstLanguageSpeaking = firstLanguageSpeaking;
         this.secondLanguageListening = secondLanguageListening;
         this.secondLanguageSpeaking = secondLanguageSpeaking;
+
         this.familyStructure = familyStructure;
-        this.customFamilyStructure = customFamilyStructure;
+        // CUSTOM이 아닌 경우 null 처리
+        this.customFamilyStructure = (familyStructure == FamilyStructure.CUSTOM) ? customFamilyStructure : null;
+
         this.storyPreference = storyPreference;
-        this.customStoryPreference = customStoryPreference;
+        this.customStoryPreference = (storyPreference == StoryPreference.CUSTOM) ? customStoryPreference : null;
+
         this.childNationality = childNationality;
         this.parentCountry = parentCountry;
 
@@ -157,20 +251,5 @@ public class UserProfile {
 
         // updatedAt 명시적 갱신 (Hibernate가 처리하지만 명확성을 위해 유지)
         this.updatedAt = LocalDateTime.now();
-    }
-
-    // 나이 그룹에서 실제 나이 자동 계산 (@PrePersist / @PreUpdate)
-    @PrePersist
-    @PreUpdate
-    public void calculateChildAge() {
-        if (this.ageGroup != null) {
-            this.childAge = this.ageGroup.getRepresentativeAge();
-        }
-    }
-
-    // 하위 호환성: primaryLanguage/secondaryLanguage 자동 동기화
-    public void syncLegacyLanguages() {
-        this.primaryLanguage = this.firstLanguage;
-        this.secondaryLanguage = this.secondLanguage;
     }
 }

--- a/src/main/java/com/moretale/domain/profile/service/UserProfileService.java
+++ b/src/main/java/com/moretale/domain/profile/service/UserProfileService.java
@@ -1,6 +1,7 @@
 package com.moretale.domain.profile.service;
 
 import com.moretale.domain.profile.dto.*;
+import com.moretale.domain.profile.entity.Language;
 import com.moretale.domain.profile.entity.UserProfile;
 import com.moretale.domain.profile.repository.UserProfileRepository;
 import com.moretale.domain.user.entity.User;
@@ -37,32 +38,46 @@ public class UserProfileService {
             throw new CustomException(ErrorCode.PROFILE_ALREADY_EXISTS);
         }
 
+        // OTHER가 아닌 경우 customLanguage는 null 처리 (Entity에서도 처리하지만 명시적으로)
+        String customFirst = (request.getFirstLanguage() == Language.OTHER)
+                ? request.getCustomFirstLanguage() : null;
+        String customSecond = (request.getSecondLanguage() == Language.OTHER)
+                ? request.getCustomSecondLanguage() : null;
+
         UserProfile profile = UserProfile.builder()
                 .user(user)
                 .childName(request.getChildName())
                 .ageGroup(request.getAgeGroup())
+                // 언어 (Enum + Custom)
                 .firstLanguage(request.getFirstLanguage())
+                .customFirstLanguage(customFirst)
                 .firstLanguageProficiency(request.getFirstLanguageProficiency())
                 .secondLanguage(request.getSecondLanguage())
+                .customSecondLanguage(customSecond)
                 .secondLanguageProficiency(request.getSecondLanguageProficiency())
+                // 능력
                 .firstLanguageListening(request.getFirstLanguageListening())
                 .firstLanguageSpeaking(request.getFirstLanguageSpeaking())
                 .secondLanguageListening(request.getSecondLanguageListening())
                 .secondLanguageSpeaking(request.getSecondLanguageSpeaking())
+                // 가족/이야기
                 .familyStructure(request.getFamilyStructure())
                 .customFamilyStructure(request.getCustomFamilyStructure())
                 .storyPreference(request.getStoryPreference())
                 .customStoryPreference(request.getCustomStoryPreference())
+                // 부가
                 .childNationality(request.getChildNationality())
                 .parentCountry(request.getParentCountry())
                 .build();
 
-        // 하위 호환성 유지 (primary/secondaryLanguage 세팅)
+        // Legacy primaryLanguage / secondaryLanguage 동기화
         profile.syncLegacyLanguages();
 
         UserProfile savedProfile = userProfileRepository.save(profile);
-        log.info("온보딩 프로필 생성 완료 - profileId: {}, childName: {}",
-                savedProfile.getProfileId(), savedProfile.getChildName());
+        log.info("온보딩 프로필 생성 완료 - profileId: {}, firstLanguage: {}, secondLanguage: {}",
+                savedProfile.getProfileId(),
+                savedProfile.getFirstLanguageDisplay(),
+                savedProfile.getSecondLanguageDisplay());
 
         return OnboardingProfileResponse.fromEntity(savedProfile);
     }
@@ -80,13 +95,20 @@ public class UserProfileService {
             throw new CustomException(ErrorCode.PROFILE_ALREADY_EXISTS);
         }
 
+        String customFirst = (request.getFirstLanguage() == Language.OTHER)
+                ? request.getCustomFirstLanguage() : null;
+        String customSecond = (request.getSecondLanguage() == Language.OTHER)
+                ? request.getCustomSecondLanguage() : null;
+
         UserProfile profile = UserProfile.builder()
                 .user(user)
                 .childName(request.getChildName())
                 .ageGroup(request.getAgeGroup())
                 .firstLanguage(request.getFirstLanguage())
+                .customFirstLanguage(customFirst)
                 .firstLanguageProficiency(request.getFirstLanguageProficiency())
                 .secondLanguage(request.getSecondLanguage())
+                .customSecondLanguage(customSecond)
                 .secondLanguageProficiency(request.getSecondLanguageProficiency())
                 .firstLanguageListening(request.getFirstLanguageListening())
                 .firstLanguageSpeaking(request.getFirstLanguageSpeaking())
@@ -132,8 +154,7 @@ public class UserProfileService {
     public UserProfileResponse updateProfile(Long userId, Long profileId, UserProfileRequest request) {
         log.info("프로필 수정 시작 - userId: {}, profileId: {}", userId, profileId);
 
-        // 사용자 존재 확인
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 프로필 존재 확인
@@ -150,8 +171,10 @@ public class UserProfileService {
                 request.getChildName(),
                 request.getAgeGroup(),
                 request.getFirstLanguage(),
+                request.getCustomFirstLanguage(),
                 request.getFirstLanguageProficiency(),
                 request.getSecondLanguage(),
+                request.getCustomSecondLanguage(),
                 request.getSecondLanguageProficiency(),
                 request.getFirstLanguageListening(),
                 request.getFirstLanguageSpeaking(),
@@ -165,8 +188,7 @@ public class UserProfileService {
                 request.getParentCountry()
         );
 
-        log.info("프로필 수정 완료 - profileId: {}, childName: {}", profile.getProfileId(), profile.getChildName());
-
+        log.info("프로필 수정 완료 - profileId: {}", profile.getProfileId());
         return UserProfileResponse.fromEntity(profile);
     }
 
@@ -175,11 +197,29 @@ public class UserProfileService {
     public UserProfileResponse updateLanguage(Long profileId, LanguageUpdateRequest request) {
         log.info("언어 설정 수정 - profileId: {}", profileId);
 
+        // LanguageUpdateRequest 자체 검증 (OTHER + custom 누락 체크)
+        request.validate();
+
         UserProfile profile = userProfileRepository.findById(profileId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND));
 
-        profile.setPrimaryLanguage(request.getPrimaryLanguage());
-        profile.setSecondaryLanguage(request.getSecondaryLanguage());
+        // Enum 기반으로 언어 업데이트
+        profile.setFirstLanguage(request.getFirstLanguage());
+        profile.setCustomFirstLanguage(
+                request.getFirstLanguage() == Language.OTHER ? request.getCustomFirstLanguage() : null
+        );
+        profile.setSecondLanguage(request.getSecondLanguage());
+        profile.setCustomSecondLanguage(
+                request.getSecondLanguage() == Language.OTHER ? request.getCustomSecondLanguage() : null
+        );
+
+        // Legacy 동기화
+        profile.syncLegacyLanguages();
+
+        log.info("언어 설정 수정 완료 - profileId: {}, first: {}, second: {}",
+                profileId,
+                profile.getFirstLanguageDisplay(),
+                profile.getSecondLanguageDisplay());
 
         return UserProfileResponse.fromEntity(profile);
     }

--- a/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
@@ -1,6 +1,7 @@
 package com.moretale.domain.story.dto;
 
 import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.entity.UserProfile;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -47,8 +48,8 @@ public class StoryInitResponse {
         return StoryInitResponse.builder()
                 .profileId(profile.getProfileId())
                 .childName(profile.getChildName())
-                .firstLanguage(profile.getFirstLanguage())
-                .secondLanguage(profile.getSecondLanguage())
+                .firstLanguage(profile.getFirstLanguageDisplay())
+                .secondLanguage(profile.getSecondLanguageDisplay())
                 .ageGroup(profile.getAgeGroup())
                 .childAge(profile.getChildAge())
                 .firstLanguageProficiency(profile.getFirstLanguageProficiency())

--- a/src/main/java/com/moretale/domain/story/service/StoryService.java
+++ b/src/main/java/com/moretale/domain/story/service/StoryService.java
@@ -1,7 +1,16 @@
 package com.moretale.domain.story.service;
 
+import com.moretale.domain.profile.entity.Language;
 import com.moretale.domain.profile.entity.StoryPreference;
-import com.moretale.domain.story.dto.*;
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.StoryGenerateRequest;
+import com.moretale.domain.story.dto.StoryGenerateResponse;
+import com.moretale.domain.story.dto.StoryInitResponse;
+import com.moretale.domain.story.dto.StoryListResponse;
+import com.moretale.domain.story.dto.StoryResponse;
+import com.moretale.domain.story.dto.StorySaveRequest;
+import com.moretale.domain.story.dto.StoryShareRequest;
 import com.moretale.domain.story.entity.Slide;
 import com.moretale.domain.story.entity.Story;
 import com.moretale.domain.story.entity.StoryToken;
@@ -11,8 +20,6 @@ import com.moretale.domain.story.repository.StoryRepository;
 import com.moretale.domain.story.repository.StoryTokenRepository;
 import com.moretale.domain.story.util.PromptBuilder;
 import com.moretale.domain.user.entity.User;
-import com.moretale.domain.profile.entity.UserProfile;
-import com.moretale.domain.profile.repository.UserProfileRepository;
 import com.moretale.domain.user.repository.UserRepository;
 import com.moretale.global.exception.BusinessException;
 import com.moretale.global.exception.ErrorCode;
@@ -36,8 +43,6 @@ public class StoryService {
     private final UserProfileRepository userProfileRepository;
     private final AIStoryService aiStoryService;
     private final TTSService ttsService;
-
-    // 추가
     private final StoryTokenService storyTokenService;
     private final StoryTokenRepository storyTokenRepository;
 
@@ -50,17 +55,11 @@ public class StoryService {
         // 이야기 선호도에 맞는 전래동화 자동 매핑
         TraditionalTale recommendedTale;
 
-        if (profile.getStoryPreference() == StoryPreference.CUSTOM &&
-                profile.getCustomStoryPreference() != null) {
-            // CUSTOM인 경우 customStoryPreference 텍스트 분석
-            recommendedTale = TraditionalTale.findByCustomText(
-                    profile.getCustomStoryPreference()
-            );
+        if (profile.getStoryPreference() == StoryPreference.CUSTOM
+                && profile.getCustomStoryPreference() != null) {
+            recommendedTale = TraditionalTale.findByCustomText(profile.getCustomStoryPreference());
         } else {
-            // 일반적인 경우
-            recommendedTale = TraditionalTale.findByPreference(
-                    profile.getStoryPreference()
-            );
+            recommendedTale = TraditionalTale.findByPreference(profile.getStoryPreference());
         }
 
         log.info("동화 초기값 조회 - userId={}, profileId={}, 추천 전래동화={}",
@@ -79,9 +78,8 @@ public class StoryService {
         // 추천 전래동화 선택
         TraditionalTale tale;
 
-        if (profile.getStoryPreference() == StoryPreference.CUSTOM &&
-                profile.getCustomStoryPreference() != null) {
-            // CUSTOM인 경우 customStoryPreference 텍스트 분석
+        if (profile.getStoryPreference() == StoryPreference.CUSTOM
+                && profile.getCustomStoryPreference() != null) {
             tale = TraditionalTale.findByCustomText(profile.getCustomStoryPreference());
 
             // CUSTOM이면 전래동화 대신 사용자 입력 텍스트 사용
@@ -105,8 +103,8 @@ public class StoryService {
                 .prompt(basePrompt)
                 .profileId(profileId)
                 .childName(profile.getChildName())
-                .primaryLanguage(profile.getFirstLanguage())
-                .secondaryLanguage(profile.getSecondLanguage())
+                .primaryLanguage(resolvePrimaryLanguage(profile))
+                .secondaryLanguage(resolveSecondaryLanguage(profile))
                 .ageGroup(profile.getAgeGroup())
                 .childAge(profile.getChildAge())
                 .firstLanguageProficiency(profile.getFirstLanguageProficiency())
@@ -140,11 +138,11 @@ public class StoryService {
 
         String primaryLang = request.getPrimaryLanguage() != null
                 ? request.getPrimaryLanguage()
-                : profile.getFirstLanguage();
+                : resolvePrimaryLanguage(profile);
 
         String secondaryLang = request.getSecondaryLanguage() != null
                 ? request.getSecondaryLanguage()
-                : profile.getSecondLanguage();
+                : resolveSecondaryLanguage(profile);
 
         // 온보딩 데이터가 요청에 없으면 프로필에서 가져옴
         if (request.getAgeGroup() == null) {
@@ -171,7 +169,7 @@ public class StoryService {
                 childName,
                 primaryLang,
                 secondaryLang,
-                request // 온보딩 제약 조건 전달
+                request
         );
 
         // TTS 생성
@@ -182,6 +180,7 @@ public class StoryService {
                             ttsService.generateTTS(slide.getTextKr(), primaryLang + "-KR")
                     );
                 }
+
                 if (slide.getTextNative() != null) {
                     slide.setAudioUrlNative(
                             ttsService.generateTTS(
@@ -191,11 +190,8 @@ public class StoryService {
                     );
                 }
             } catch (Exception e) {
-                log.error(
-                        "TTS 생성 중 오류 발생 (건너뜀) - slideOrder={}",
-                        slide.getOrder(),
-                        e
-                );
+                log.error("TTS 생성 중 오류 발생 (건너뜀) - slideOrder={}",
+                        slide.getOrder(), e);
             }
         });
 
@@ -225,8 +221,8 @@ public class StoryService {
                 .prompt(request.getPrompt())
                 .user(user)
                 .childName(profile.getChildName())
-                .primaryLanguage(profile.getPrimaryLanguage())
-                .secondaryLanguage(profile.getSecondaryLanguage())
+                .primaryLanguage(resolvePrimaryLanguage(profile))
+                .secondaryLanguage(resolveSecondaryLanguage(profile))
                 .isPublic(false)
                 .build();
 
@@ -249,11 +245,8 @@ public class StoryService {
         Story savedStory = storyRepository.save(story);
         slideRepository.saveAll(savedStory.getSlides());
 
-        // 토큰 생성 및 저장 (동화 저장 시점에 미리 생성)
-        String sourceLanguage = profile.getPrimaryLanguage() != null
-                ? profile.getPrimaryLanguage() : "ko";
-        String targetLanguage = profile.getSecondaryLanguage() != null
-                ? profile.getSecondaryLanguage() : "en";
+        String sourceLanguage = resolvePrimaryLanguage(profile);
+        String targetLanguage = resolveSecondaryLanguage(profile);
 
         savedStory.getSlides().forEach(slide -> {
             try {
@@ -267,7 +260,9 @@ public class StoryService {
             }
         });
 
-        log.info("동화 저장 완료 - storyId={}, userId={}", savedStory.getStoryId(), user.getUserId());
+        log.info("동화 저장 완료 - storyId={}, userId={}",
+                savedStory.getStoryId(), user.getUserId());
+
         return StoryResponse.from(savedStory);
     }
 
@@ -333,8 +328,49 @@ public class StoryService {
                     .findByProfileIdAndUser_UserId(profileId, user.getUserId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
         }
+
         return userProfileRepository
                 .findFirstByUserOrderByCreatedAtDesc(user)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+    }
+
+    /**
+     * Story/TTS/토큰 생성 등 기존 문자열 기반 로직에서 사용할 첫 번째 언어 문자열 반환
+     * - 일반 언어: ISO 코드 반환 (ko, en, ja ...)
+     * - OTHER: 사용자가 직접 입력한 문자열 반환
+     * - null: 기본값 ko
+     */
+    private String resolvePrimaryLanguage(UserProfile profile) {
+        if (profile.getFirstLanguage() == null) {
+            return "ko";
+        }
+
+        if (profile.getFirstLanguage() == Language.OTHER) {
+            return profile.getCustomFirstLanguage() != null && !profile.getCustomFirstLanguage().isBlank()
+                    ? profile.getCustomFirstLanguage()
+                    : "other";
+        }
+
+        return profile.getFirstLanguage().getIsoCode();
+    }
+
+    /**
+     * Story/TTS/토큰 생성 등 기존 문자열 기반 로직에서 사용할 두 번째 언어 문자열 반환
+     * - 일반 언어: ISO 코드 반환 (ko, en, ja ...)
+     * - OTHER: 사용자가 직접 입력한 문자열 반환
+     * - null: 기본값 en
+     */
+    private String resolveSecondaryLanguage(UserProfile profile) {
+        if (profile.getSecondLanguage() == null) {
+            return "en";
+        }
+
+        if (profile.getSecondLanguage() == Language.OTHER) {
+            return profile.getCustomSecondLanguage() != null && !profile.getCustomSecondLanguage().isBlank()
+                    ? profile.getCustomSecondLanguage()
+                    : "other";
+        }
+
+        return profile.getSecondLanguage().getIsoCode();
     }
 }

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -37,7 +37,13 @@ public class SecurityConfig {
                                 "/", "/login",
                                 "/index.html", "/login.html",
                                 "/css/**", "/js/**", "/images/**",
-                                "/oauth2/**", "/login/oauth2/**"
+                                "/oauth2/**", "/login/oauth2/**",
+
+                                // Swagger / OpenAPI
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**"
                         ).permitAll()
 
                         // 공개 API

--- a/src/main/java/com/moretale/global/validation/LanguageInputValidator.java
+++ b/src/main/java/com/moretale/global/validation/LanguageInputValidator.java
@@ -1,0 +1,75 @@
+package com.moretale.global.validation;
+
+import com.moretale.domain.profile.entity.FamilyStructure;
+import com.moretale.domain.profile.entity.Language;
+import com.moretale.domain.profile.entity.StoryPreference;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * @ValidLanguageInput 실제 검증 로직
+ *
+ * ConstraintValidator<어노테이션, 검증 대상 타입>
+ * → DTO 클래스 레벨에 적용
+ */
+public class LanguageInputValidator implements ConstraintValidator<ValidLanguageInput, Object> {
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+
+        // Reflection 없이 인터페이스로 접근하기 위해 LanguageValidatable 인터페이스 사용
+        if (!(value instanceof LanguageValidatable target)) {
+            return true;
+        }
+
+        boolean valid = true;
+        context.disableDefaultConstraintViolation();
+
+        // 1. firstLanguage == OTHER → customFirstLanguage 필수
+        if (Language.OTHER.equals(target.getFirstLanguage())) {
+            if (isBlank(target.getCustomFirstLanguage())) {
+                context.buildConstraintViolationWithTemplate(
+                        "'기타' 선택 시 첫 번째 언어를 직접 입력해주세요."
+                ).addPropertyNode("customFirstLanguage").addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        // 2. secondLanguage == OTHER → customSecondLanguage 필수
+        if (Language.OTHER.equals(target.getSecondLanguage())) {
+            if (isBlank(target.getCustomSecondLanguage())) {
+                context.buildConstraintViolationWithTemplate(
+                        "'기타' 선택 시 두 번째 언어를 직접 입력해주세요."
+                ).addPropertyNode("customSecondLanguage").addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        // 3. familyStructure == CUSTOM → customFamilyStructure 필수
+        if (FamilyStructure.CUSTOM.equals(target.getFamilyStructure())) {
+            if (isBlank(target.getCustomFamilyStructure())) {
+                context.buildConstraintViolationWithTemplate(
+                        "'직접 작성' 선택 시 가족 구조를 입력해주세요."
+                ).addPropertyNode("customFamilyStructure").addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        // 4. storyPreference == CUSTOM → customStoryPreference 필수
+        if (StoryPreference.CUSTOM.equals(target.getStoryPreference())) {
+            if (isBlank(target.getCustomStoryPreference())) {
+                context.buildConstraintViolationWithTemplate(
+                        "'직접 적을래요' 선택 시 이야기 선호도를 입력해주세요."
+                ).addPropertyNode("customStoryPreference").addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        return valid;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/moretale/global/validation/LanguageValidatable.java
+++ b/src/main/java/com/moretale/global/validation/LanguageValidatable.java
@@ -1,0 +1,18 @@
+package com.moretale.global.validation;
+
+import com.moretale.domain.profile.entity.FamilyStructure;
+import com.moretale.domain.profile.entity.Language;
+import com.moretale.domain.profile.entity.StoryPreference;
+
+// @ValidLanguageInput 검증에 필요한 필드 접근 인터페이스
+// OnboardingProfileRequest / UserProfileRequest 양쪽에서 구현
+public interface LanguageValidatable {
+    Language getFirstLanguage();
+    String getCustomFirstLanguage();
+    Language getSecondLanguage();
+    String getCustomSecondLanguage();
+    FamilyStructure getFamilyStructure();
+    String getCustomFamilyStructure();
+    StoryPreference getStoryPreference();
+    String getCustomStoryPreference();
+}

--- a/src/main/java/com/moretale/global/validation/ValidLanguageInput.java
+++ b/src/main/java/com/moretale/global/validation/ValidLanguageInput.java
@@ -1,0 +1,26 @@
+package com.moretale.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+/**
+ * 언어 Enum + Custom 입력 복합 검증 어노테이션
+ *
+ * 적용 규칙:
+ * - firstLanguage == OTHER  → customFirstLanguage 필수 (null/blank 불가)
+ * - firstLanguage != OTHER  → customFirstLanguage 무시 (자동 null 처리)
+ * - secondLanguage 동일하게 적용
+ * - familyStructure == CUSTOM  → customFamilyStructure 필수
+ * - storyPreference == CUSTOM  → customStoryPreference 필수
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = LanguageInputValidator.class)
+@Documented
+public @interface ValidLanguageInput {
+    String message() default "언어 입력이 올바르지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/resources/db/migration/V2__language_enum_migration.sql
+++ b/src/main/resources/db/migration/V2__language_enum_migration.sql
@@ -1,0 +1,44 @@
+-- 1. 컬럼 추가 (PostgreSQL) --
+ALTER TABLE user_profiles
+    ADD COLUMN first_language_enum VARCHAR(10),
+    ADD COLUMN custom_first_language VARCHAR(100),
+    ADD COLUMN second_language_enum VARCHAR(10),
+    ADD COLUMN custom_second_language VARCHAR(100);
+
+-- 2. 기존 데이터 → Enum 변환
+UPDATE user_profiles
+SET first_language_enum = CASE first_language
+    WHEN 'ko' THEN 'KO'
+    WHEN 'en' THEN 'EN'
+    WHEN 'ja' THEN 'JA'
+    WHEN 'zh' THEN 'ZH'
+    WHEN 'es' THEN 'ES'
+    WHEN 'vi' THEN 'VI'
+    ELSE 'OTHER'
+END,
+custom_first_language = CASE
+    WHEN first_language NOT IN ('ko','en','ja','zh','es','vi') THEN first_language
+    ELSE NULL
+END;
+
+UPDATE user_profiles
+SET second_language_enum = CASE second_language
+    WHEN 'ko' THEN 'KO'
+    WHEN 'en' THEN 'EN'
+    WHEN 'ja' THEN 'JA'
+    WHEN 'zh' THEN 'ZH'
+    WHEN 'es' THEN 'ES'
+    WHEN 'vi' THEN 'VI'
+    ELSE 'OTHER'
+END,
+custom_second_language = CASE
+    WHEN second_language NOT IN ('ko','en','ja','zh','es','vi') THEN second_language
+    ELSE NULL
+END;
+
+-- 3. NOT NULL 제약 (PostgreSQL) --
+ALTER TABLE user_profiles
+    ALTER COLUMN first_language_enum SET NOT NULL;
+
+ALTER TABLE user_profiles
+    ALTER COLUMN second_language_enum SET NOT NULL;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -91,36 +91,148 @@
         <form id="createForm" onsubmit="createProfile(event)">
             <div class="form-group">
                 <label for="createChildName">아이 이름 *</label>
-                <input type="text" id="createChildName" placeholder="예: 유찬" required>
+                <input type="text" id="createChildName" required>
             </div>
+
             <div class="form-group">
-                <label for="createChildAge">아이 나이 *</label>
-                <input type="number" id="createChildAge" min="1" max="18" placeholder="예: 8" required>
+                <label for="createAgeGroup">아이 나이 그룹 *</label>
+                <select id="createAgeGroup" required>
+                    <option value="AGE_0_2">0-2세</option>
+                    <option value="AGE_3_4">3-4세</option>
+                    <option value="AGE_5_6">5-6세</option>
+                    <option value="AGE_7_8">7-8세</option>
+                    <option value="AGE_9_10">9-10세</option>
+                    <option value="AGE_10_PLUS">10세 이상</option>
+                </select>
             </div>
+
             <div class="form-group">
                 <label for="createChildNationality">자녀 국적</label>
-                <input type="text" id="createChildNationality" placeholder="예: 대한민국">
+                <input type="text" id="createChildNationality" placeholder="예: KR">
             </div>
+
             <div class="form-group">
                 <label for="createParentCountry">부모 출신 국가 *</label>
-                <input type="text" id="createParentCountry" placeholder="예: 중국, 베트남" required>
+                <input type="text" id="createParentCountry" placeholder="예: KR" required>
             </div>
+
             <div class="form-group">
-                <label for="createPrimaryLanguage">기본 언어 *</label>
-                <select id="createPrimaryLanguage" required>
-                    <option value="ko">한국어 (ko)</option>
-                    <option value="en">영어 (en)</option>
+                <label for="createFirstLanguage">기본 언어 *</label>
+                <select id="createFirstLanguage" onchange="toggleCustomInput('createFirstLanguage', 'createCustomFirstLanguage')" required>
+                    <option value="KO">한국어</option>
+                    <option value="EN">영어</option>
+                    <option value="JA">일본어</option>
+                    <option value="ZH">중국어</option>
+                    <option value="ES">스페인어</option>
+                    <option value="VI">베트남어</option>
+                    <option value="OTHER">기타</option>
                 </select>
             </div>
+
+            <div class="form-group hidden" id="createCustomFirstLanguageWrapper">
+                <label for="createCustomFirstLanguage">기본 언어 직접 입력</label>
+                <input type="text" id="createCustomFirstLanguage" placeholder="예: 태국어">
+            </div>
+
             <div class="form-group">
-                <label for="createSecondaryLanguage">부모 언어 *</label>
-                <select id="createSecondaryLanguage" required>
-                    <option value="zh">중국어 (zh)</option>
-                    <option value="vi">베트남어 (vi)</option>
-                    <option value="en">영어 (en)</option>
-                    <option value="ja">일본어 (ja)</option>
+                <label for="createSecondLanguage">부모 언어 *</label>
+                <select id="createSecondLanguage" onchange="toggleCustomInput('createSecondLanguage', 'createCustomSecondLanguage')" required>
+                    <option value="KO">한국어</option>
+                    <option value="EN">영어</option>
+                    <option value="JA">일본어</option>
+                    <option value="ZH">중국어</option>
+                    <option value="ES">스페인어</option>
+                    <option value="VI">베트남어</option>
+                    <option value="OTHER">기타</option>
                 </select>
             </div>
+
+            <div class="form-group hidden" id="createCustomSecondLanguageWrapper">
+                <label for="createCustomSecondLanguage">부모 언어 직접 입력</label>
+                <input type="text" id="createCustomSecondLanguage" placeholder="예: 힌디어">
+            </div>
+
+            <div class="form-group">
+                <label for="createFirstLanguageProficiency">기본 언어 숙련도 *</label>
+                <select id="createFirstLanguageProficiency" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createSecondLanguageProficiency">부모 언어 숙련도 *</label>
+                <select id="createSecondLanguageProficiency" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createFirstLanguageListening">기본 언어 듣기 *</label>
+                <select id="createFirstLanguageListening" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createFirstLanguageSpeaking">기본 언어 말하기 *</label>
+                <select id="createFirstLanguageSpeaking" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createSecondLanguageListening">부모 언어 듣기 *</label>
+                <select id="createSecondLanguageListening" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createSecondLanguageSpeaking">부모 언어 말하기 *</label>
+                <select id="createSecondLanguageSpeaking" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createFamilyStructure">가족 구조 *</label>
+                <select id="createFamilyStructure" required>
+                    <option value="ONE_PARENT">한 분과 살아요</option>
+                    <option value="TWO_PARENTS">두 분과 살아요</option>
+                    <option value="EXTENDED_FAMILY">다른 가족과 살아요</option>
+                    <option value="SECRET">비밀이에요</option>
+                    <option value="CUSTOM">직접 작성해요</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="createStoryPreference">이야기 선호도 *</label>
+                <select id="createStoryPreference" required>
+                    <option value="WARM_HUG">포근포근 안아주는 이야기</option>
+                    <option value="FUN_ADVENTURE">신나는 모험 이야기</option>
+                    <option value="DAILY_LIFE">오늘 하루를 담은 이야기</option>
+                    <option value="CUSTOM">직접 적을래요</option>
+                </select>
+            </div>
+
             <button type="submit" class="btn-primary">등록하기</button>
             <div id="createStatus" class="status"></div>
         </form>
@@ -133,34 +245,146 @@
                 <label for="updateChildName">아이 이름 *</label>
                 <input type="text" id="updateChildName" required>
             </div>
+
             <div class="form-group">
-                <label for="updateChildAge">아이 나이 *</label>
-                <input type="number" id="updateChildAge" min="1" max="18" required>
+                <label for="updateAgeGroup">아이 나이 그룹 *</label>
+                <select id="updateAgeGroup" required>
+                    <option value="AGE_0_2">0-2세</option>
+                    <option value="AGE_3_4">3-4세</option>
+                    <option value="AGE_5_6">5-6세</option>
+                    <option value="AGE_7_8">7-8세</option>
+                    <option value="AGE_9_10">9-10세</option>
+                    <option value="AGE_10_PLUS">10세 이상</option>
+                </select>
             </div>
+
             <div class="form-group">
                 <label for="updateChildNationality">자녀 국적</label>
                 <input type="text" id="updateChildNationality">
             </div>
+
             <div class="form-group">
                 <label for="updateParentCountry">부모 출신 국가 *</label>
                 <input type="text" id="updateParentCountry" required>
             </div>
+
             <div class="form-group">
-                <label for="updatePrimaryLanguage">기본 언어 *</label>
-                <select id="updatePrimaryLanguage" required>
-                    <option value="ko">한국어 (ko)</option>
-                    <option value="en">영어 (en)</option>
+                <label for="updateFirstLanguage">기본 언어 *</label>
+                <select id="updateFirstLanguage" onchange="toggleCustomInput('updateFirstLanguage', 'updateCustomFirstLanguage')" required>
+                    <option value="KO">한국어</option>
+                    <option value="EN">영어</option>
+                    <option value="JA">일본어</option>
+                    <option value="ZH">중국어</option>
+                    <option value="ES">스페인어</option>
+                    <option value="VI">베트남어</option>
+                    <option value="OTHER">기타</option>
                 </select>
             </div>
+
+            <div class="form-group hidden" id="updateCustomFirstLanguageWrapper">
+                <label for="updateCustomFirstLanguage">기본 언어 직접 입력</label>
+                <input type="text" id="updateCustomFirstLanguage">
+            </div>
+
             <div class="form-group">
-                <label for="updateSecondaryLanguage">부모 언어 *</label>
-                <select id="updateSecondaryLanguage" required>
-                    <option value="zh">중국어 (zh)</option>
-                    <option value="vi">베트남어 (vi)</option>
-                    <option value="en">영어 (en)</option>
-                    <option value="ja">일본어 (ja)</option>
+                <label for="updateSecondLanguage">부모 언어 *</label>
+                <select id="updateSecondLanguage" onchange="toggleCustomInput('updateSecondLanguage', 'updateCustomSecondLanguage')" required>
+                    <option value="KO">한국어</option>
+                    <option value="EN">영어</option>
+                    <option value="JA">일본어</option>
+                    <option value="ZH">중국어</option>
+                    <option value="ES">스페인어</option>
+                    <option value="VI">베트남어</option>
+                    <option value="OTHER">기타</option>
                 </select>
             </div>
+
+            <div class="form-group hidden" id="updateCustomSecondLanguageWrapper">
+                <label for="updateCustomSecondLanguage">부모 언어 직접 입력</label>
+                <input type="text" id="updateCustomSecondLanguage">
+            </div>
+
+            <div class="form-group">
+                <label for="updateFirstLanguageProficiency">기본 언어 숙련도 *</label>
+                <select id="updateFirstLanguageProficiency" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateSecondLanguageProficiency">부모 언어 숙련도 *</label>
+                <select id="updateSecondLanguageProficiency" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateFirstLanguageListening">기본 언어 듣기 *</label>
+                <select id="updateFirstLanguageListening" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateFirstLanguageSpeaking">기본 언어 말하기 *</label>
+                <select id="updateFirstLanguageSpeaking" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateSecondLanguageListening">부모 언어 듣기 *</label>
+                <select id="updateSecondLanguageListening" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateSecondLanguageSpeaking">부모 언어 말하기 *</label>
+                <select id="updateSecondLanguageSpeaking" required>
+                    <option value="EGG">알</option>
+                    <option value="LARVA">애벌레</option>
+                    <option value="PUPA">번데기</option>
+                    <option value="BEE">꿀벌</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateFamilyStructure">가족 구조 *</label>
+                <select id="updateFamilyStructure" required>
+                    <option value="ONE_PARENT">한 분과 살아요</option>
+                    <option value="TWO_PARENTS">두 분과 살아요</option>
+                    <option value="EXTENDED_FAMILY">다른 가족과 살아요</option>
+                    <option value="SECRET">비밀이에요</option>
+                    <option value="CUSTOM">직접 작성해요</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="updateStoryPreference">이야기 선호도 *</label>
+                <select id="updateStoryPreference" required>
+                    <option value="WARM_HUG">포근포근 안아주는 이야기</option>
+                    <option value="FUN_ADVENTURE">신나는 모험 이야기</option>
+                    <option value="DAILY_LIFE">오늘 하루를 담은 이야기</option>
+                    <option value="CUSTOM">직접 적을래요</option>
+                </select>
+            </div>
+
             <button type="submit" class="btn-primary">정보 업데이트</button>
             <button type="button" class="btn-secondary" onclick="showTab('view')">취소</button>
             <div id="updateStatus" class="status"></div>
@@ -205,8 +429,23 @@
         document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
         document.getElementById('btn-' + tabName).classList.add('active');
 
-        if(tabName !== 'update') {
+        if (tabName !== 'update') {
             document.getElementById('btn-update').style.display = 'none';
+        }
+    }
+
+    function toggleCustomInput(selectId, inputId) {
+        const select = document.getElementById(selectId);
+        const wrapper = document.getElementById(inputId + 'Wrapper');
+        const input = document.getElementById(inputId);
+
+        if (select.value === 'OTHER') {
+            wrapper.classList.remove('hidden');
+            input.required = true;
+        } else {
+            wrapper.classList.add('hidden');
+            input.required = false;
+            input.value = '';
         }
     }
 
@@ -219,10 +458,11 @@
             if (result.success) {
                 document.getElementById('userEmail').textContent = result.data.email;
             }
-        } catch (e) { console.error(e); }
+        } catch (e) {
+            console.error(e);
+        }
     }
 
-    // 1:N 목록 조회 로직
     async function loadProfile() {
         const profileList = document.getElementById('profileList');
         const emptyProfile = document.getElementById('emptyProfile');
@@ -240,21 +480,25 @@
 
             if (result.success && result.data.length > 0) {
                 profileList.innerHTML = '';
+
                 result.data.forEach(p => {
                     profileList.innerHTML += `
                         <div class="profile-item">
                             <p><strong>아이 이름</strong><span>${p.childName}</span></p>
                             <p><strong>나이</strong><span>${p.childAge}세</span></p>
-                            <p><strong>부모 언어</strong><span>${p.secondaryLanguage}</span></p>
+                            <p><strong>기본 언어</strong><span>${p.firstLanguageDisplay ?? '-'}</span></p>
+                            <p><strong>부모 언어</strong><span>${p.secondLanguageDisplay ?? '-'}</span></p>
                             <button class="btn-edit" onclick="prepareUpdate(${p.profileId})">✏️ 수정하기</button>
                         </div>
                     `;
                 });
+
                 profileList.classList.remove('hidden');
             } else {
                 emptyProfile.classList.remove('hidden');
             }
         } catch (e) {
+            console.error(e);
             emptyProfile.classList.remove('hidden');
         } finally {
             loading.style.display = 'none';
@@ -263,83 +507,162 @@
 
     async function createProfile(event) {
         event.preventDefault();
+
         const data = {
             childName: document.getElementById('createChildName').value,
-            childAge: parseInt(document.getElementById('createChildAge').value),
+            ageGroup: document.getElementById('createAgeGroup').value,
+            firstLanguage: document.getElementById('createFirstLanguage').value,
+            customFirstLanguage: document.getElementById('createCustomFirstLanguage').value || null,
+            firstLanguageProficiency: document.getElementById('createFirstLanguageProficiency').value,
+            secondLanguage: document.getElementById('createSecondLanguage').value,
+            customSecondLanguage: document.getElementById('createCustomSecondLanguage').value || null,
+            secondLanguageProficiency: document.getElementById('createSecondLanguageProficiency').value,
+            firstLanguageListening: document.getElementById('createFirstLanguageListening').value,
+            firstLanguageSpeaking: document.getElementById('createFirstLanguageSpeaking').value,
+            secondLanguageListening: document.getElementById('createSecondLanguageListening').value,
+            secondLanguageSpeaking: document.getElementById('createSecondLanguageSpeaking').value,
+            familyStructure: document.getElementById('createFamilyStructure').value,
+            customFamilyStructure: null,
+            storyPreference: document.getElementById('createStoryPreference').value,
+            customStoryPreference: null,
             childNationality: document.getElementById('createChildNationality').value || null,
-            parentCountry: document.getElementById('createParentCountry').value,
-            primaryLanguage: document.getElementById('createPrimaryLanguage').value,
-            secondaryLanguage: document.getElementById('createSecondaryLanguage').value
+            parentCountry: document.getElementById('createParentCountry').value
         };
 
         try {
-            const response = await fetch(`${API_BASE_URL}/users/profile`, {
+            const response = await fetch(`${API_BASE_URL}/users/profile/onboarding`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${authToken}` },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${authToken}`
+                },
                 body: JSON.stringify(data)
             });
+
             const result = await response.json();
+
             if (result.success) {
                 showStatus('createStatus', '✅ 등록 성공!', 'success');
-                setTimeout(() => { document.getElementById('createForm').reset(); showTab('view'); loadProfile(); }, 1000);
+                setTimeout(() => {
+                    document.getElementById('createForm').reset();
+                    document.getElementById('createCustomFirstLanguageWrapper').classList.add('hidden');
+                    document.getElementById('createCustomSecondLanguageWrapper').classList.add('hidden');
+                    showTab('view');
+                    loadProfile();
+                }, 1000);
             } else {
                 showStatus('createStatus', '❌ ' + result.message, 'error');
             }
-        } catch (e) { showStatus('createStatus', '❌ 오류 발생', 'error'); }
+        } catch (e) {
+            console.error(e);
+            showStatus('createStatus', '❌ 오류 발생', 'error');
+        }
     }
 
     async function prepareUpdate(profileId) {
         editingProfileId = profileId;
+
         try {
             const response = await fetch(`${API_BASE_URL}/users/profile/${profileId}`, {
                 headers: { 'Authorization': `Bearer ${authToken}` }
             });
+
             const result = await response.json();
+
             if (result.success) {
                 const p = result.data;
-                document.getElementById('updateChildName').value = p.childName;
-                document.getElementById('updateChildAge').value = p.childAge;
-                document.getElementById('updateChildNationality').value = p.childNationality || '';
-                document.getElementById('updateParentCountry').value = p.parentCountry;
-                document.getElementById('updatePrimaryLanguage').value = p.primaryLanguage;
-                document.getElementById('updateSecondaryLanguage').value = p.secondaryLanguage;
+
+                document.getElementById('updateChildName').value = p.childName ?? '';
+                document.getElementById('updateAgeGroup').value = p.ageGroup ?? 'AGE_5_6';
+                document.getElementById('updateChildNationality').value = p.childNationality ?? '';
+                document.getElementById('updateParentCountry').value = p.parentCountry ?? '';
+
+                document.getElementById('updateFirstLanguage').value = p.firstLanguage ?? 'KO';
+                document.getElementById('updateCustomFirstLanguage').value = p.customFirstLanguage ?? '';
+                toggleCustomInput('updateFirstLanguage', 'updateCustomFirstLanguage');
+
+                document.getElementById('updateSecondLanguage').value = p.secondLanguage ?? 'EN';
+                document.getElementById('updateCustomSecondLanguage').value = p.customSecondLanguage ?? '';
+                toggleCustomInput('updateSecondLanguage', 'updateCustomSecondLanguage');
+
+                document.getElementById('updateFirstLanguageProficiency').value = p.firstLanguageProficiency ?? 'LARVA';
+                document.getElementById('updateSecondLanguageProficiency').value = p.secondLanguageProficiency ?? 'LARVA';
+                document.getElementById('updateFirstLanguageListening').value = p.firstLanguageListening ?? 'LARVA';
+                document.getElementById('updateFirstLanguageSpeaking').value = p.firstLanguageSpeaking ?? 'LARVA';
+                document.getElementById('updateSecondLanguageListening').value = p.secondLanguageListening ?? 'LARVA';
+                document.getElementById('updateSecondLanguageSpeaking').value = p.secondLanguageSpeaking ?? 'LARVA';
+                document.getElementById('updateFamilyStructure').value = p.familyStructure ?? 'TWO_PARENTS';
+                document.getElementById('updateStoryPreference').value = p.storyPreference ?? 'DAILY_LIFE';
 
                 document.getElementById('btn-update').style.display = 'block';
                 showTab('update');
             }
-        } catch (e) { alert("정보를 불러오지 못했습니다."); }
+        } catch (e) {
+            console.error(e);
+            alert('정보를 불러오지 못했습니다.');
+        }
     }
 
     async function updateProfile(event) {
         event.preventDefault();
+
         const data = {
             childName: document.getElementById('updateChildName').value,
-            childAge: parseInt(document.getElementById('updateChildAge').value),
+            ageGroup: document.getElementById('updateAgeGroup').value,
+            firstLanguage: document.getElementById('updateFirstLanguage').value,
+            customFirstLanguage: document.getElementById('updateCustomFirstLanguage').value || null,
+            firstLanguageProficiency: document.getElementById('updateFirstLanguageProficiency').value,
+            secondLanguage: document.getElementById('updateSecondLanguage').value,
+            customSecondLanguage: document.getElementById('updateCustomSecondLanguage').value || null,
+            secondLanguageProficiency: document.getElementById('updateSecondLanguageProficiency').value,
+            firstLanguageListening: document.getElementById('updateFirstLanguageListening').value,
+            firstLanguageSpeaking: document.getElementById('updateFirstLanguageSpeaking').value,
+            secondLanguageListening: document.getElementById('updateSecondLanguageListening').value,
+            secondLanguageSpeaking: document.getElementById('updateSecondLanguageSpeaking').value,
+            familyStructure: document.getElementById('updateFamilyStructure').value,
+            customFamilyStructure: null,
+            storyPreference: document.getElementById('updateStoryPreference').value,
+            customStoryPreference: null,
             childNationality: document.getElementById('updateChildNationality').value || null,
-            parentCountry: document.getElementById('updateParentCountry').value,
-            primaryLanguage: document.getElementById('updatePrimaryLanguage').value,
-            secondaryLanguage: document.getElementById('updateSecondaryLanguage').value
+            parentCountry: document.getElementById('updateParentCountry').value
         };
 
         try {
             const response = await fetch(`${API_BASE_URL}/users/profile/${editingProfileId}`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${authToken}` },
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${authToken}`
+                },
                 body: JSON.stringify(data)
             });
+
             const result = await response.json();
+
             if (result.success) {
                 showStatus('updateStatus', '✅ 수정 완료!', 'success');
-                setTimeout(() => { showTab('view'); loadProfile(); }, 1000);
+                setTimeout(() => {
+                    showTab('view');
+                    loadProfile();
+                }, 1000);
+            } else {
+                showStatus('updateStatus', '❌ ' + result.message, 'error');
             }
-        } catch (e) { showStatus('updateStatus', '❌ 수정 실패', 'error'); }
+        } catch (e) {
+            console.error(e);
+            showStatus('updateStatus', '❌ 수정 실패', 'error');
+        }
     }
 
     function showStatus(id, msg, type) {
         const s = document.getElementById(id);
         s.textContent = msg;
         s.className = `status ${type}`;
-        setTimeout(() => s.style.display = 'none', 3000);
+        s.style.display = 'block';
+
+        setTimeout(() => {
+            s.style.display = 'none';
+        }, 3000);
     }
 
     function logout() {


### PR DESCRIPTION
## 📌 관련 이슈
- close #31

## ✨ 작업 내용 요약
- 프로필 언어 입력 구조를 기존 String 기반에서 `Enum` + `Custom` 입력 구조로 개편
  - `Language Enum(KO/EN/JA/ZH/ES/VI/OTHER)` 도입 및 OTHER 선택 시 직접 입력(`customFirstLanguage` / `customSecondLanguage`) 지원
- 온보딩 및 사용자 프로필 요청 DTO를 `Enum` 기반 구조로 변경하고, `@ValidLanguageInput`을 통한 언어/가족구조/스토리선호도 교차 필드 검증 로직 추가
- `UserProfile` 엔티티에 `Enum` 언어 필드 및 `custom` 언어 컬럼 추가
- 기존 `primaryLanguage`/`secondaryLanguage`와의 하위 호환을 위한 동기화 로직 구현
- 프로필 및 온보딩 응답 DTO에 `languageDisplay` 필드 추가하여 프론트에서 바로 사용할 수 있는 표시용 언어 값 제공
- `StoryInitResponse` 및 동화 생성 로직에서 `Enum` 기반 언어를 `display` 값으로 변환하도록 수정
- Swagger UI 접근을 위한 `SecurityConfig` 설정 추가 (`/swagger-ui/`, `/v3/api-docs/` 등 허용)
- 임시 프론트 `index.html`에서 `Enum` 기반 요청 및 `display` 필드 응답 구조에 맞도록 수정 및 연동 확인

## 🗒️ 참고 사항
- 기존 String 기반 언어 필드(`primaryLanguage`, `secondaryLanguage`)는 하위 호환을 위해 유지되며 `Enum` → String 자동 동기화 방식으로 동작
- OTHER 선택 시 `custom` 값 입력이 필수이며, `@ValidLanguageInput`을 통해 서버에서 일관된 검증 수행
- 응답 DTO에 `languageDisplay` 필드를 추가하여 프론트에서 `Enum` 변환 없이 바로 표시 가능하도록 개선
- 동화 생성 및 초기값 조회 시 언어는 `display` 기준으로 내려가도록 수정되어 사용자 입력(`custom` 언어 포함)이 그대로 반영됨
- DB는 `Enum` 컬럼(`first_language_enum`, `second_language_enum`)과 `custom` 컬럼을 기준으로 관리되며 기존 데이터는 마이그레이션 스크립트를 통해 변환 처리