### PR TITLE
Feat/18-deploy-infra

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.idea
+.gradle
+out
+*.log
+*.md
+gradlew.bat
+src/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
+# 1. Build stage
+FROM gradle:8.7-jdk21 AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar --no-daemon -x test
+
+# 2. Runtime stage
 FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
 RUN mkdir -p /app/uploads
 
-COPY build/libs/*.jar app.jar
+COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+RUN mkdir -p /app/uploads
+
+COPY build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]

--- a/src/main/java/com/moretale/global/config/SwaggerConfig.java
+++ b/src/main/java/com/moretale/global/config/SwaggerConfig.java
@@ -1,0 +1,59 @@
+package com.moretale.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${server.url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(securitySchemeName);
+
+        Server localServer = new Server()
+                .url("http://localhost:8080")
+                .description("로컬 개발 서버");
+
+        Server deployServer = new Server()
+                .url(serverUrl)
+                .description("배포 서버 (Render / GCP)");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MORETALE API")
+                        .description("""
+                                MORETALE API 명세서입니다.
+                                
+                                **인증 방식**
+                                - Google OAuth2 로그인 후 발급받은 JWT 토큰을 사용합니다.
+                                - Authorize 버튼을 눌러 `Bearer {토큰}` 형식으로 입력하세요.
+                                """)
+                        .version("v1.0.0"))
+                .servers(List.of(localServer, deployServer))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 server:
-  port: 8080
+  port: ${PORT:8080}
 
 spring:
   profiles:
-    active: dev  # dev 프로필 활성화 (MockTTSServiceImpl 사용)
+    active: ${SPRING_PROFILES_ACTIVE:dev}
 
   # 데이터베이스 설정
   datasource:
@@ -65,8 +65,8 @@ jwt:
 # 파일 업로드 설정
 file:
   upload:
-    base-path: ${user.home}/moretale/uploads
-    base-url: http://localhost:8080/uploads
+    base-path: ${FILE_UPLOAD_PATH:${user.home}/moretale/uploads}
+    base-url: ${FILE_BASE_URL:http://localhost:8080/uploads}
 
 # TTS 저장 경로
 tts:
@@ -91,3 +91,25 @@ google:
       base-url: https://storage.googleapis.com
     credentials:
       location: classpath:gcp-service-account.json
+
+---
+# prod 프로필 (Docker / GCP 환경)
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+  sql:
+    init:
+      mode: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,7 +107,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
   sql:


### PR DESCRIPTION
## 📌 관련 이슈
- close #40

## ✨ 작업 내용 요약
- Docker 기반 배포 환경 구축 (`Dockerfile`, `.dockerignore` 추가)
- Gradle 빌드를 포함한 멀티 스테이지 Docker 이미지 생성 구조 적용
- Render를 활용한 백엔드 서비스 배포 및 외부 접근 가능 환경 구성
- Render PostgreSQL 연동을 통해 운영 환경 DB 연결 설정
- 환경변수 기반 설정으로 `application.yml` 구조 개선 (dev / prod 프로파일 분리)
- Swagger OpenAPI 설정 추가 및 JWT 인증 스키마 적용
- 배포 환경에서 Swagger UI 외부 접근 가능하도록 서버 URL 설정

## 🗒️ 참고 사항
- Render는 Swagger 확인 및 테스트용 배포 환경으로 사용 (최종 배포는 GCP 예정)
- OAuth(Google 로그인)는 `redirect_uri` 미설정으로 현재 Render에서는 동작하지 않으며, GCP 배포 시 재설정 필요
- 초기 배포 시 테이블 자동 생성을 위해 `ddl-auto: update`로 설정 (추후 운영 환경에서는 `validate`로 변경 필요)