### PR TITLE
Refactor/22-vocabulary-query-optimization-v2

### DIFF
--- a/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
@@ -56,26 +56,48 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     void deleteAllByUser(User user);
 
     /**
-     * 도서관 목록 조회 - Pageable 정렬 파라미터 지원
-     * 프론트 정렬 UI 매핑:
-     *   최신순    → sort=createdAt,desc
-     *   오래된순  → sort=createdAt,asc
-     *   가나다순  → sort=title,asc
+     * 도서관 목록 조회 1단계 - story_id만 페이징 조회 (N+1 + 메모리 페이징 방지 핵심)
+     *
+     * ─ 기존 문제 ──────────────────────────────────────────────────────────────
+     *   findByUserIdWithSlides(): LEFT JOIN FETCH s.slides + Pageable 조합
+     *   → Hibernate가 전체 결과를 메모리에 올린 후 페이징 (HHH90003004 경고)
+     *   → OOM 위험 + 불필요한 대량 데이터 로딩
+     *
+     * ─ 해결 방법 ──────────────────────────────────────────────────────────────
+     *   1차 쿼리(findIdsByUserId): story_id만 OFFSET/LIMIT으로 정확히 페이징
+     *   2차 쿼리(fetchByIdsWithSlides): IN 절로 slides까지 JOIN FETCH 일괄 조회
+     *
+     * ─ countQuery 분리 이유 ───────────────────────────────────────────────────
+     *   fetch join 없이 COUNT만 하면 불필요한 JOIN 제거 → 성능 향상
+     * ─────────────────────────────────────────────────────────────────────────
      */
     @Query(
             value = """
-                SELECT DISTINCT s FROM Story s
-                LEFT JOIN FETCH s.slides sl
-                WHERE s.user.userId = :userId
+            SELECT s.storyId FROM Story s
+            WHERE s.user.userId = :userId
             """,
             countQuery = """
-                SELECT COUNT(s) FROM Story s
-                WHERE s.user.userId = :userId
+            SELECT COUNT(s) FROM Story s
+            WHERE s.user.userId = :userId
             """
     )
-    Page<Story> findByUserIdWithSlides(@Param("userId") Long userId, Pageable pageable);
+    Page<Long> findIdsByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    // 도서관 목록 조회 - 슬라이드 없이 (경량 버전)
+    /**
+     * 도서관 목록 조회 2단계 - ID 목록으로 slides까지 JOIN FETCH 일괄 조회
+     *
+     * ─ IN 절 크기 = 한 페이지 크기(기본 20)이므로 성능 문제 없음
+     * ─ DISTINCT: story - slide 1:N 조인으로 중복 story 행이 생길 수 있으므로 필수
+     * ─ 순서 보장: IN 절은 DB 반환 순서 미보장 → Service에서 원래 ID 순서대로 재정렬
+     */
+    @Query("""
+        SELECT DISTINCT s FROM Story s
+        LEFT JOIN FETCH s.slides sl
+        WHERE s.storyId IN :ids
+    """)
+    List<Story> fetchByIdsWithSlides(@Param("ids") List<Long> ids);
+
+    // 도서관 목록 조회 - 슬라이드 없이 (경량 버전, 필요 시 사용)
     @Query("""
         SELECT s FROM Story s
         WHERE s.user.userId = :userId
@@ -88,4 +110,26 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
         WHERE s.isPublic = true
     """)
     Page<Story> findPublicStories(Pageable pageable);
+
+    /**
+     * 기존 메서드 - 사용하지 않지만 하위 호환을 위해 유지
+     *
+     * 주의: Pageable + fetch join 조합으로 메모리 페이징 발생 (HHH90003004)
+     * 도서관 목록 조회에는 findIdsByUserId + fetchByIdsWithSlides 방식 사용 권장
+     *
+     * @deprecated LibraryService.getLibrary()에서 더 이상 사용하지 않음
+     */
+    @Deprecated
+    @Query(
+            value = """
+            SELECT DISTINCT s FROM Story s
+            LEFT JOIN FETCH s.slides sl
+            WHERE s.user.userId = :userId
+            """,
+            countQuery = """
+            SELECT COUNT(s) FROM Story s
+            WHERE s.user.userId = :userId
+            """
+    )
+    Page<Story> findByUserIdWithSlides(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/moretale/domain/story/service/LibraryService.java
+++ b/src/main/java/com/moretale/domain/story/service/LibraryService.java
@@ -11,11 +11,17 @@ import com.moretale.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * 도서관 전용 서비스
@@ -34,12 +40,23 @@ public class LibraryService {
     private final VocabularyEntryRepository vocabularyEntryRepository;
 
     /**
-     * 도서관 목록 조회 (페이징 + 정렬)
+     * 도서관 목록 조회 (페이징 + 정렬) — N+1 및 메모리 페이징 개선 버전
      *
-     * 프론트 정렬 파라미터 매핑: [cite: 254, 319]
-     * 최신순   → GET /api/library?sort=createdAt,desc
-     * 오래된순 → GET /api/library?sort=createdAt,asc
-     * 가나다순 → GET /api/library?sort=title,asc
+     * ─ 개선 전 흐름 ───────────────────────────────────────────────────────────
+     *   findByUserIdWithSlides(): LEFT JOIN FETCH + Pageable 조합
+     *   → HHH90003004: 전체 결과를 메모리에 올린 후 페이징 처리
+     *   → 동화가 많을수록 OOM 위험 증가
+     *
+     * ─ 개선 후 흐름 ───────────────────────────────────────────────────────────
+     *   1단계: story_id만 OFFSET/LIMIT으로 정확히 페이징 (메모리 페이징 없음)
+     *   2단계: 해당 ID 목록으로 slides까지 JOIN FETCH 일괄 조회 (IN 절, 최대 20개)
+     *   3단계: 원래 ID 순서대로 재정렬 후 Page 재구성
+     *   → 합계: 최대 3번 (count 포함)
+     *
+     * ─ 프론트 정렬 파라미터 매핑 ──────────────────────────────────────────────
+     *   최신순   → GET /api/library?sort=createdAt,desc
+     *   오래된순 → GET /api/library?sort=createdAt,asc
+     *   가나다순 → GET /api/library?sort=title,asc
      *
      * @param userId   인증된 사용자 ID
      * @param pageable Spring Pageable (sort 파라미터 포함)
@@ -48,15 +65,35 @@ public class LibraryService {
     public Page<StoryLibraryCardResponse> getLibrary(Long userId, Pageable pageable) {
         Pageable safePageable = buildSafePageable(pageable);
 
-        Page<Story> stories = storyRepository.findByUserIdWithSlides(userId, safePageable);
+        // 1단계: story_id만 페이징 조회
+        Page<Long> idPage = storyRepository.findIdsByUserId(userId, safePageable);
+        List<Long> ids = idPage.getContent();
 
         log.info("도서관 조회 - userId={}, page={}, sort={}, totalElements={}",
                 userId,
                 pageable.getPageNumber(),
-                pageable.getSort(),
-                stories.getTotalElements());
+                safePageable.getSort(),
+                idPage.getTotalElements());
 
-        return stories.map(StoryLibraryCardResponse::from);
+        // 결과가 없으면 빈 페이지 즉시 반환
+        if (ids.isEmpty()) {
+            return new PageImpl<>(List.of(), safePageable, 0);
+        }
+
+        // 2단계: ID 목록으로 slides까지 JOIN FETCH 일괄 조회
+        List<Story> stories = storyRepository.fetchByIdsWithSlides(ids);
+
+        // 3단계: IN 절 조회는 DB 반환 순서가 보장되지 않으므로 원래 순서로 재정렬
+        Map<Long, Story> storyMap = stories.stream()
+                .collect(Collectors.toMap(Story::getStoryId, Function.identity()));
+
+        List<StoryLibraryCardResponse> content = ids.stream()
+                .filter(storyMap::containsKey)          // 혹시 모를 누락 방어
+                .map(id -> StoryLibraryCardResponse.from(storyMap.get(id)))
+                .collect(Collectors.toList());
+
+        // 4단계: 1단계의 totalElements를 재사용하여 Page 재구성
+        return new PageImpl<>(content, safePageable, idPage.getTotalElements());
     }
 
     /**

--- a/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
+++ b/src/main/java/com/moretale/domain/vocabulary/repository/VocabularyEntryRepository.java
@@ -43,14 +43,17 @@ public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry
     void deleteAllByStory(Story story);
 
     /**
-     * 통합 필터 조회 (즐겨찾기 + 키워드 + 동화 필터 조합)
+     * 통합 필터 조회 — ID만 페이징 조회 (N+1 방지 핵심)
      *
-     * ─ keyword 처리 방식 변경 ────────────────────────────────────────────────
-     *   기존: LIKE CONCAT('%', :keyword, '%') — PostgreSQL + Hibernate 6 조합에서
-     *         keyword=null 시 파라미터 타입을 bytea로 추론하여 타입 오류 발생
+     * ─ 왜 ID만 조회하는가? ────────────────────────────────────────────────────
+     *   Pageable + fetch join 조합 시 Hibernate는 전체 결과를 메모리에 올린 후
+     *   페이징 처리(HHH90003004 경고)하여 OOM 위험이 있다.
+     *   따라서 1차 쿼리에서는 ID만 가져와 페이징을 정확히 적용하고,
+     *   2차 쿼리(fetchByIds)에서 연관 엔티티를 fetch join으로 한 번에 가져온다.
      *
-     *   변경: :keywordPattern 으로 받고, Service에서 null → null, 값 → "%값%" 변환
-     *         IS NULL 분기와 LIKE 절의 파라미터를 분리하여 타입 충돌 방지
+     * ─ keyword 처리 방식 ──────────────────────────────────────────────────────
+     *   :keywordPattern 으로 받고, Service에서 null → null, 값 → "%값%" 변환
+     *   IS NULL 분기와 LIKE 절의 파라미터를 분리하여 타입 충돌 방지
      * ─────────────────────────────────────────────────────────────────────────
      *
      * @param userId         사용자 ID (필수)
@@ -59,22 +62,51 @@ public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry
      * @param keywordPattern LIKE 패턴 문자열 (null이면 전체, 값이면 "%keyword%")
      * @param pageable       페이징 + 정렬 (isFavorite DESC가 선행 적용된 Pageable)
      */
-    @Query("""
-    SELECT v FROM VocabularyEntry v
-    WHERE v.user.userId = :userId
-      AND (:storyId IS NULL OR v.story.storyId = :storyId)
-      AND (:favorite IS NULL OR v.isFavorite = :favorite)
-      AND (:keywordPattern IS NULL
-            OR v.word LIKE :keywordPattern
-            OR v.translation LIKE :keywordPattern)
-""")
-    Page<VocabularyEntry> findWithFilters(
+    @Query(
+            value = """
+            SELECT v.vocabularyId FROM VocabularyEntry v
+            WHERE v.user.userId = :userId
+              AND (:storyId IS NULL OR v.story.storyId = :storyId)
+              AND (:favorite IS NULL OR v.isFavorite = :favorite)
+              AND (:keywordPattern IS NULL
+                    OR v.word LIKE :keywordPattern
+                    OR v.translation LIKE :keywordPattern)
+            """,
+            countQuery = """
+            SELECT COUNT(v) FROM VocabularyEntry v
+            WHERE v.user.userId = :userId
+              AND (:storyId IS NULL OR v.story.storyId = :storyId)
+              AND (:favorite IS NULL OR v.isFavorite = :favorite)
+              AND (:keywordPattern IS NULL
+                    OR v.word LIKE :keywordPattern
+                    OR v.translation LIKE :keywordPattern)
+            """
+    )
+    Page<Long> findIdsByFilters(
             @Param("userId") Long userId,
             @Param("storyId") Long storyId,
             @Param("favorite") Boolean favorite,
             @Param("keywordPattern") String keywordPattern,
             Pageable pageable
     );
+
+    /**
+     * ID 목록으로 VocabularyEntry + 연관 엔티티 일괄 fetch join 조회
+     *
+     * story / slide / storyToken 을 JOIN FETCH 하여
+     * VocabularyResponse.from() 내 Lazy Loading이 발생하지 않도록 한다.
+     *
+     * ※ 순서 보장: IN 절 조회는 DB 반환 순서가 보장되지 않으므로
+     *   Service 레이어에서 원래 ID 순서대로 재정렬한다.
+     */
+    @Query("""
+        SELECT v FROM VocabularyEntry v
+        JOIN FETCH v.story
+        JOIN FETCH v.slide
+        JOIN FETCH v.storyToken
+        WHERE v.vocabularyId IN :ids
+        """)
+    List<VocabularyEntry> fetchByIds(@Param("ids") List<Long> ids);
 
     // 즐겨찾기 단어 전체 조회 (페이징)
     Page<VocabularyEntry> findByUser_UserIdAndIsFavoriteTrue(Long userId, Pageable pageable);

--- a/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
+++ b/src/main/java/com/moretale/domain/vocabulary/service/VocabularyService.java
@@ -24,6 +24,7 @@ import com.moretale.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -33,6 +34,9 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -119,24 +123,25 @@ public class VocabularyService {
     }
 
     /**
-     * 단어장 통합 필터 조회
+     * 단어장 통합 필터 조회 - N+1 개선 버전
      *
-     * ─ 정렬 정책 (isFavorite 우선) ──────────────────────────────────────────
-     *   buildSafeVocabularyPageable() 에서 isFavorite DESC 를 맨 앞에 고정하고
-     *   사용자가 선택한 정렬(createdAt / word)을 그 뒤에 붙인다.
+     * 기존에는 Vocabulary 조회 후 story / slide / storyToken을
+     * Lazy Loading으로 개별 조회하여 N+1 문제가 발생했다.
      *
-     *   결과 ORDER BY 예시:
-     *     최신순   →  isFavorite DESC, createdAt DESC
-     *     오래된순 →  isFavorite DESC, createdAt ASC
-     *     가나다순 →  isFavorite DESC, word ASC
-     * ─────────────────────────────────────────────────────────────────────────
+     * 이를 해결하기 위해:
+     * 1. ID만 페이징 조회
+     * 2. fetch join으로 연관 엔티티 일괄 조회
+     * 3. 원래 순서대로 재정렬 후 Page 재구성
      *
-     * 단, favorite=true 필터가 걸린 경우에는 결과가 모두 즐겨찾기이므로
-     * isFavorite DESC 선행 정렬이 의미 없어 생략한다. (불필요한 ORDER BY 제거)
+     * Pageable + fetch join 사용 시 발생하는 메모리 페이징 문제를
+     * 피하기 위해 2단계 조회 방식으로 구현하였다.
+     *
+     * 정렬은 isFavorite DESC를 우선 적용하며,
+     * 이후 createdAt 또는 word 정렬을 추가한다.
      *
      * @param userId    사용자 ID
-     * @param condition 필터 조건 (storyId, favorite, keyword)
-     * @param pageable  페이징 + 정렬
+     * @param condition 필터 조건
+     * @param pageable  페이징 및 정렬 정보
      */
     public Page<VocabularyResponse> getWithFilters(
             Long userId,
@@ -156,15 +161,36 @@ public class VocabularyService {
                 userId, condition.getStoryId(), condition.getFavorite(),
                 keywordPattern, safePageable.getSort());
 
-        return vocabularyEntryRepository
-                .findWithFilters(
-                        userId,
-                        condition.getStoryId(),
-                        condition.getFavorite(),
-                        keywordPattern,
-                        safePageable
-                )
-                .map(VocabularyResponse::from);
+        // 1단계: vocabulary_id + 총 개수만 페이징 조회
+        Page<Long> idPage = vocabularyEntryRepository.findIdsByFilters(
+                userId,
+                condition.getStoryId(),
+                condition.getFavorite(),
+                keywordPattern,
+                safePageable
+        );
+
+        List<Long> ids = idPage.getContent();
+
+        // 결과가 없으면 빈 페이지 즉시 반환
+        if (ids.isEmpty()) {
+            return idPage.map(id -> null); // 타입 맞추기용 트릭 — 아래 방식으로 대체
+        }
+
+        // 2단계: ID 목록으로 연관 엔티티 JOIN FETCH 일괄 조회
+        List<VocabularyEntry> entries = vocabularyEntryRepository.fetchByIds(ids);
+
+        // 3단계: IN 절 조회는 DB 반환 순서가 보장되지 않으므로 원래 순서로 재정렬
+        Map<Long, VocabularyEntry> entryMap = entries.stream()
+                .collect(Collectors.toMap(VocabularyEntry::getVocabularyId, Function.identity()));
+
+        List<VocabularyResponse> content = ids.stream()
+                .filter(entryMap::containsKey)       // 혹시 모를 누락 방어
+                .map(id -> VocabularyResponse.from(entryMap.get(id)))
+                .collect(Collectors.toList());
+
+        // 4단계: 1단계의 totalElements를 재사용하여 Page 재구성
+        return new PageImpl<>(content, safePageable, idPage.getTotalElements());
     }
 
     // 단어가 저장된 동화 목록 조회
@@ -221,7 +247,7 @@ public class VocabularyService {
      * 단어장 정렬 필드 화이트리스트 검증 + isFavorite DESC 선행 삽입
      *
      * ─ 정렬 규칙 ────────────────────────────────────────────────────────────
-     *   1. 허용 필드: isFavorite, createdAt, word  (그 외는 무시)
+     *   1. 허용 필드: createdAt, word  (그 외는 무시)
      *   2. skipFavoriteSort = false 인 경우 (기본):
      *        → isFavorite DESC 를 정렬 맨 앞에 고정
      *        → 이후 사용자 요청 정렬(createdAt / word)을 추가
@@ -236,9 +262,6 @@ public class VocabularyService {
      *        → isFavorite DESC 삽입 생략 (결과가 이미 전부 즐겨찾기)
      *        → 사용자 요청 정렬만 적용
      * ─────────────────────────────────────────────────────────────────────────
-     *
-     * @param pageable          원본 Pageable (Controller에서 전달)
-     * @param skipFavoriteSort  true이면 isFavorite DESC 선행 삽입 생략
      */
     private Pageable buildSafeVocabularyPageable(Pageable pageable, boolean skipFavoriteSort) {
         Sort sort = pageable.getSort();
@@ -278,20 +301,12 @@ public class VocabularyService {
         );
     }
 
-    /**
-     * skipFavoriteSort = false 로 고정하는 편의 오버로드
-     * (기존 getAll, getByStory 등에서 사용)
-     */
+    // skipFavoriteSort = false 로 고정하는 편의 오버로드
     private Pageable buildSafeVocabularyPageable(Pageable pageable) {
         return buildSafeVocabularyPageable(pageable, false);
     }
 
-    /**
-     * 사용자가 sort 파라미터로 직접 지정할 수 있는 허용 필드
-     * - createdAt : 최신순 / 오래된순
-     * - word      : 가나다순
-     * (isFavorite은 Service 내부에서 자동 삽입하므로 사용자 입력 허용 안 함)
-     */
+    // 사용자가 sort 파라미터로 직접 지정할 수 있는 허용 필드
     private boolean isAllowedVocabSortField(String field) {
         return "createdAt".equals(field) || "word".equals(field);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #48

## ✨ 작업 내용 요약

- Vocabulary 통합 필터 조회 API(`/api/vocabulary`)의 N+1 문제 개선
- 기존 `findWithFilters()` 단일 조회 구조를 `ID 페이징 조회 → fetch join 조회`의 2단계 전략으로 리팩토링
- `findIdsByFilters()` 추가:
  - `vocabulary_id`만 먼저 페이징 조회하여 정확한 OFFSET/LIMIT 적용
  - `countQuery` 분리로 total count 유지
- `fetchByIds()` 추가:
  - `story`, `slide`, `storyToken`을 `JOIN FETCH`로 일괄 조회
  - DTO 변환 과정에서 Lazy Loading 발생 제거
- Service 레이어에서:
  - ID 목록 기반 조회 후 원래 순서대로 재정렬
  - `PageImpl`로 최종 Page 재구성
- SQL 로그 기준:
  - 기존: `1 + N` 이상의 반복 SELECT 발생
  - 개선 후: `ID 조회 1번 + fetch join 1번 (+ count)` 구조로 개선
- `Pageable + fetch join` 사용 시 발생 가능한 Hibernate 메모리 페이징(`HHH90003004`) 문제 방지 구조 적용
- 단어장 정렬 정책(`isFavorite DESC` 우선 정렬) 유지 및 기존 필터 기능 호환
- Library 조회 API(`/api/library`)의 메모리 페이징 및 fetch join 구조 개선
- 기존 `findByUserIdWithSlides()`의 `LEFT JOIN FETCH + Pageable` 구조를 `story_id 페이징 조회 → slides fetch join 조회` 방식으로 리팩토링
- `findIdsByUserId()` 추가:
  - `story_id`만 먼저 OFFSET/LIMIT 기반 페이징 조회
  - `countQuery` 분리로 전체 count 유지
- `fetchByIdsWithSlides()` 추가:
  - `slides`를 `JOIN FETCH`로 일괄 조회
  - `DISTINCT` 적용으로 중복 Story 제거
- Service 레이어에서:
  - IN 절 조회 후 원래 ID 순서대로 재정렬
  - `PageImpl` 기반 최종 Page 재구성
- SQL 로그 기준:
  - 기존: `HHH90003004` 경고 발생 및 메모리 페이징 수행
  - 개선 후: DB 레벨 OFFSET/LIMIT 적용 + fetch join 분리 구조로 개선
- 기존 `findByUserIdWithSlides()`는 하위 호환을 위해 `@Deprecated` 처리

## 🗒️ 참고 사항
- SQL 로그 기준 Vocabulary 조회의 반복 SELECT 제거 여부 확인 완료
- `VocabularyResponse.from()` 내부 Lazy Loading 추가 발생하지 않는 것 확인
- SQL 로그 기준 Library 조회의 `HHH90003004` 경고 제거 확인 완료
- IN 절 조회는 DB 반환 순서를 보장하지 않으므로 Service 레이어에서 ID 기준 재정렬 처리
- 두 API 모두 데이터 증가 시 기존 구조 대비 조회 성능 개선 효과 기대
- fetch join과 Pageable을 직접 함께 사용하지 않도록 하여 메모리 페이징 위험 감소
- #50, #51 에서 library 부분 추가한 버전