### PR TITLE
Refactor/23-story-cascade-save-flow

### DIFF
--- a/src/main/java/com/moretale/domain/story/entity/Slide.java
+++ b/src/main/java/com/moretale/domain/story/entity/Slide.java
@@ -46,10 +46,9 @@ public class Slide {
     /**
      * 토큰 연관관계
      *
-     * @BatchSize(size = 50):
-     *   슬라이드가 N개일 때 tokens를 N번 SELECT하는 대신,
-     *   IN (:slideId1, :slideId2, ...) 방식으로 최대 50개씩 묶어 조회
-     *   -> N+1 쿼리를 ceil(N/50)회로 대폭 감소
+     * CascadeType.ALL: Slide 저장 시 연결된 StoryToken도 함께 저장됨.
+     * orphanRemoval = true: 컬렉션에서 제거된 Token은 자동 삭제됨.
+     * @BatchSize(size = 50): tokens 조회 시 IN 절 배치 조회로 N+1 완화
      */
     @BatchSize(size = 50)
     @OneToMany(mappedBy = "slide", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -57,9 +56,17 @@ public class Slide {
     @Builder.Default
     private List<StoryToken> tokens = new ArrayList<>();
 
-    // 편의 메서드
+    // 토큰 연관관계 편의 메서드
+    // token.slide 설정을 통해 Slide와 연결되며, CascadeType.ALL에 의해 자동 저장됨.
     public void addToken(StoryToken token) {
         tokens.add(token);
         token.setSlide(this);
+    }
+
+    // 토큰 연관관계 해제 편의 메서드
+    // orphanRemoval = true 이므로 컬렉션에서 제거 시 자동 DELETE
+    public void removeToken(StoryToken token) {
+        tokens.remove(token);
+        token.setSlide(null);
     }
 }

--- a/src/main/java/com/moretale/domain/story/entity/Story.java
+++ b/src/main/java/com/moretale/domain/story/entity/Story.java
@@ -12,21 +12,25 @@ import java.util.List;
 /**
  * 동화 엔티티
  *
- * ── 삭제 cascade 흐름 ────────────────────────────────────────────────
- * storyRepository.delete(story) 호출 시:
+ * ── 저장 cascade 흐름 ────────────────────────────────────────────────────────
+ *   storyRepository.save(story) 호출 시:
+ *     Story INSERT → Slide INSERT (CascadeType.ALL)
+ *   em.flush() 후 slide.addToken(token) 호출 시:
+ *     트랜잭션 커밋 → StoryToken INSERT (Slide.tokens CascadeType.ALL)
  *
- * [JPA 레벨]
- *   Story
- *    └── Slide           (CascadeType.ALL + orphanRemoval)
- *          └── StoryToken (CascadeType.ALL + orphanRemoval)
+ * ── 삭제 cascade 흐름 ────────────────────────────────────────────────────────
+ *   storyRepository.delete(story) 호출 시:
  *
- * [DB 레벨 - @OnDelete(CASCADE)]
- *   Story 삭제 → VocabularyEntry 자동 삭제
- *   Slide  삭제 → VocabularyEntry 자동 삭제 (slide_id FK)
- *   StoryToken 삭제 → VocabularyEntry 자동 삭제 (token_id FK)
+ *   [JPA 레벨]
+ *     Story
+ *      └── Slide           (CascadeType.ALL + orphanRemoval)
+ *            └── StoryToken (CascadeType.ALL + orphanRemoval)
  *
- * 결과: Story 삭제 한 번으로 관련 모든 데이터 정리됨
- * ─────────────────────────────────────────────────────────────────────
+ *   [DB 레벨 - @OnDelete(CASCADE)]
+ *     Story 삭제 → VocabularyEntry 자동 삭제
+ *     Slide 삭제 → VocabularyEntry 자동 삭제 (slide_id FK)
+ *     StoryToken 삭제 → VocabularyEntry 자동 삭제 (token_id FK)
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 @Entity
 @Table(name = "stories")
@@ -71,8 +75,13 @@ public class Story {
 
     /**
      * 슬라이드 목록
-     * - CascadeType.ALL: Story 저장/삭제 시 Slide도 함께 저장/삭제
-     * - orphanRemoval: Story에서 제거된 Slide는 자동 삭제
+     *
+     * CascadeType.ALL:
+     *   storyRepository.save(story) 만으로 모든 Slide도 함께 저장됨.
+     *   slideRepository.saveAll() 별도 호출 불필요.
+     *
+     * orphanRemoval = true:
+     *   slides 컬렉션에서 제거된 Slide는 자동으로 DELETE됨.
      */
     @OneToMany(mappedBy = "story", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("order ASC")

--- a/src/main/java/com/moretale/domain/story/service/StoryService.java
+++ b/src/main/java/com/moretale/domain/story/service/StoryService.java
@@ -15,14 +15,13 @@ import com.moretale.domain.story.entity.Slide;
 import com.moretale.domain.story.entity.Story;
 import com.moretale.domain.story.entity.StoryToken;
 import com.moretale.domain.story.enums.TraditionalTale;
-import com.moretale.domain.story.repository.SlideRepository;
 import com.moretale.domain.story.repository.StoryRepository;
-import com.moretale.domain.story.repository.StoryTokenRepository;
 import com.moretale.domain.story.util.PromptBuilder;
 import com.moretale.domain.user.entity.User;
 import com.moretale.domain.user.repository.UserRepository;
 import com.moretale.global.exception.BusinessException;
 import com.moretale.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,13 +37,12 @@ import java.util.stream.Collectors;
 public class StoryService {
 
     private final StoryRepository storyRepository;
-    private final SlideRepository slideRepository;
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final AIStoryService aiStoryService;
     private final TTSService ttsService;
     private final StoryTokenService storyTokenService;
-    private final StoryTokenRepository storyTokenRepository;
+    private final EntityManager em;
 
     // 온보딩 데이터 기반 동화 생성 초기값 조회
     // GET /api/stories/init
@@ -206,7 +204,7 @@ public class StoryService {
         UserProfile profile = userProfileRepository.findById(request.getProfileId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
 
-        // [수정] 엔티티 equals() 비교 제거 → userId 기반 비교
+        // 엔티티 equals() 비교 제거 → userId 기반 비교
         if (!profile.getUser().getUserId().equals(userId)) {
             log.warn("보안 위반 시도 - 요청 userId={}가 userId={}의 프로필 {}을 사용하려고 함",
                     userId, profile.getUser().getUserId(), profile.getProfileId());
@@ -241,7 +239,9 @@ public class StoryService {
 
         // Story + Slide 먼저 저장 (slide_id 획득 필요)
         Story savedStory = storyRepository.save(story);
-        slideRepository.saveAll(savedStory.getSlides());
+
+        // 1차 flush: Story + Slide INSERT 실행, slideId 확보
+        em.flush();
 
         String sourceLanguage = resolvePrimaryLanguage(profile);
         String targetLanguage = resolveSecondaryLanguage(profile);
@@ -252,11 +252,13 @@ public class StoryService {
                         slide, sourceLanguage, targetLanguage
                 );
                 tokens.forEach(slide::addToken);
-                storyTokenRepository.saveAll(tokens);
             } catch (Exception e) {
                 log.error("토큰 생성 실패 (건너뜀) - slideId={}", slide.getSlideId(), e);
             }
         });
+
+        // 2차 flush: StoryToken INSERT 실행, tokenId 확보
+        em.flush();
 
         log.info("동화 저장 완료 - storyId={}, userId={}",
                 savedStory.getStoryId(), userId);
@@ -269,7 +271,7 @@ public class StoryService {
         Story story = storyRepository.findByIdWithSlides(storyId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
 
-        // [수정] story.getUser().equals(user) → userId 기반 비교
+        // story.getUser().equals(user) → userId 기반 비교
         boolean isOwner = story.getUser().getUserId().equals(userId);
         if (!isOwner && !story.getIsPublic()) {
             throw new BusinessException(ErrorCode.STORY_ACCESS_DENIED);
@@ -280,7 +282,7 @@ public class StoryService {
 
     // 내 동화 목록 조회
     public List<StoryListResponse> getMyStories(Long userId) {
-        // [수정] User 엔티티 조회 없이 userId 기반 Repository 쿼리 직접 사용
+        // User 엔티티 조회 없이 userId 기반 Repository 쿼리 직접 사용
         return storyRepository.findByUserIdOrderByCreatedAtDesc(userId)
                 .stream()
                 .map(StoryListResponse::from)
@@ -298,7 +300,7 @@ public class StoryService {
     // 동화 공유 설정 변경
     @Transactional
     public void updateStoryShareStatus(Long userId, Long storyId, StoryShareRequest request) {
-        // [수정] User 엔티티 조회 없이 userId + storyId 기반으로 직접 조회
+        // User 엔티티 조회 없이 userId + storyId 기반으로 직접 조회
         Story story = storyRepository.findByStoryIdAndUserId(storyId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
 
@@ -308,7 +310,7 @@ public class StoryService {
     // 동화 삭제
     @Transactional
     public void deleteStory(Long userId, Long storyId) {
-        // [수정] User 엔티티 조회 없이 userId + storyId 기반으로 직접 조회
+        // User 엔티티 조회 없이 userId + storyId 기반으로 직접 조회
         Story story = storyRepository.findByStoryIdAndUserId(storyId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #49

## ✨ 작업 내용 요약
- `StoryService` 저장 로직에서 `slideRepository.saveAll()` 및 `storyTokenRepository.saveAll()` 제거
- `CascadeType.ALL` 기반 연관관계 저장 구조로 리팩토링
- `EntityManager.flush()`를 추가하여 `slideId`, `tokenId` 생성 시점 명시적 보장
- `StoryResponse` 생성 시 `tokenId`가 null로 반환되던 문제 수정
- `Slide`, `Story` 엔티티의 cascade / orphanRemoval 흐름 주석 정리
- `Slide.removeToken()` 메서드 추가 및 orphanRemoval 기반 삭제 흐름 보강
- `@BatchSize(size = 50)` 기반 tokens 조회 최적화 설명 보강
- 저장/조회/삭제(Postman + DB + SQL 로그) 테스트 완료

## 🗒️ 참고 사항
- `Story.slides`, `Slide.tokens` 모두 `CascadeType.ALL + orphanRemoval = true` 기반으로 동작
- `slide.addToken(token)` 호출만으로 `StoryToken` 자동 저장되도록 구조 단순화
- SQL 로그 기준 불필요한 `UPDATE` 반복 없이 cascade 기반 INSERT 흐름 정상 동작 확인
- `DELETE /api/stories/{storyId}` 테스트 기준 Story → Slide → StoryToken cascade 삭제 정상 동작 확인
- 상세 조회 시 `@BatchSize` 기반 IN 절 조회로 N+1 완화 확인
