### PR TITLE
Refactor/24-story-tts-language-unification

### DIFF
--- a/src/main/java/com/moretale/domain/profile/controller/UserProfileController.java
+++ b/src/main/java/com/moretale/domain/profile/controller/UserProfileController.java
@@ -6,6 +6,9 @@ import com.moretale.global.common.ApiResponse;
 import com.moretale.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +46,7 @@ public class UserProfileController {
     @PostMapping("/onboarding")
     public ApiResponse<OnboardingProfileResponse> createOnboardingProfile(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @Valid @RequestBody OnboardingProfileRequest request
+            @Valid @org.springframework.web.bind.annotation.RequestBody OnboardingProfileRequest request
     ) {
         log.info("온보딩 프로필 생성 요청 - userId: {}", userPrincipal.getUserId());
         return ApiResponse.success(
@@ -64,7 +67,7 @@ public class UserProfileController {
     @PostMapping
     public ApiResponse<UserProfileResponse> createProfile(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @Valid @RequestBody UserProfileRequest request
+            @Valid @org.springframework.web.bind.annotation.RequestBody UserProfileRequest request
     ) {
         log.info("프로필 생성 요청 - userId: {}", userPrincipal.getUserId());
         return ApiResponse.success(
@@ -113,7 +116,7 @@ public class UserProfileController {
     @PutMapping("/{profileId}")
     public ApiResponse<UserProfileResponse> updateProfile(
             @Parameter(description = "프로필 ID") @PathVariable("profileId") Long profileId,
-            @Valid @RequestBody UserProfileRequest request,
+            @Valid @org.springframework.web.bind.annotation.RequestBody UserProfileRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         log.info("프로필 수정 요청 - userId: {}, profileId: {}",
@@ -131,13 +134,44 @@ public class UserProfileController {
 
                     - firstLanguage / secondLanguage Enum 값 변경
                     - OTHER 선택 시 customFirstLanguage / customSecondLanguage 필수
-                    """
+                    - 일반 언어(KO, EN, JA, ZH, ES, VI) 선택 시 custom 값은 null 사용
+                    """,
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "일반 언어 예시",
+                                            value = """
+                                                    {
+                                                      "firstLanguage": "KO",
+                                                      "customFirstLanguage": null,
+                                                      "secondLanguage": "VI",
+                                                      "customSecondLanguage": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "OTHER 언어 예시",
+                                            value = """
+                                                    {
+                                                      "firstLanguage": "KO",
+                                                      "customFirstLanguage": null,
+                                                      "secondLanguage": "OTHER",
+                                                      "customSecondLanguage": "태국어"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
     )
     @PatchMapping("/{profileId}/language")
     public ApiResponse<UserProfileResponse> updateLanguage(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "프로필 ID") @PathVariable("profileId") Long profileId,
-            @Valid @RequestBody LanguageUpdateRequest request
+            @Valid @org.springframework.web.bind.annotation.RequestBody LanguageUpdateRequest request
     ) {
         log.info("언어 설정 수정 요청 - userId: {}, profileId: {}",
                 userPrincipal.getUserId(), profileId);

--- a/src/main/java/com/moretale/domain/profile/dto/LanguageUpdateRequest.java
+++ b/src/main/java/com/moretale/domain/profile/dto/LanguageUpdateRequest.java
@@ -21,19 +21,31 @@ import lombok.*;
 public class LanguageUpdateRequest {
 
     @NotNull(message = "첫 번째 언어는 필수입니다.")
-    @Schema(description = "첫 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "KO")
+    @Schema(
+            description = "첫 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)",
+            example = "KO"
+    )
     private Language firstLanguage;
 
     @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
-    @Schema(description = "첫 번째 언어 직접 입력 (OTHER 선택 시 필수)", example = "태국어")
+    @Schema(
+            description = "첫 번째 언어 직접 입력 (OTHER 선택 시 필수, 일반 언어 선택 시 null)",
+            nullable = true
+    )
     private String customFirstLanguage;
 
     @NotNull(message = "두 번째 언어는 필수입니다.")
-    @Schema(description = "두 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)", example = "VI")
+    @Schema(
+            description = "두 번째 언어 (KO/EN/JA/ZH/ES/VI/OTHER)",
+            example = "VI"
+    )
     private Language secondLanguage;
 
     @Size(max = 100, message = "직접 입력 언어명은 100자 이하여야 합니다.")
-    @Schema(description = "두 번째 언어 직접 입력 (OTHER 선택 시 필수)", example = "힌디어")
+    @Schema(
+            description = "두 번째 언어 직접 입력 (OTHER 선택 시 필수, 일반 언어 선택 시 null)",
+            nullable = true
+    )
     private String customSecondLanguage;
 
     // OTHER 선택 시 custom 값 검증

--- a/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
+++ b/src/main/java/com/moretale/domain/profile/dto/UserProfileResponse.java
@@ -44,7 +44,10 @@ public class UserProfileResponse {
     @Schema(description = "첫 번째 언어 Enum", example = "KO")
     private Language firstLanguage;
 
-    @Schema(description = "첫 번째 언어 직접 입력값 (OTHER 시)", example = "태국어")
+    @Schema(
+            description = "첫 번째 언어 직접 입력값 (OTHER 선택 시에만 반환, 일반 언어 선택 시 null)",
+            nullable = true
+    )
     private String customFirstLanguage;
 
     @Schema(description = "첫 번째 언어 표시명", example = "한국어")
@@ -53,7 +56,10 @@ public class UserProfileResponse {
     @Schema(description = "두 번째 언어 Enum", example = "VI")
     private Language secondLanguage;
 
-    @Schema(description = "두 번째 언어 직접 입력값 (OTHER 시)", example = "힌디어")
+    @Schema(
+            description = "두 번째 언어 직접 입력값 (OTHER 선택 시에만 반환, 일반 언어 선택 시 null)",
+            nullable = true
+    )
     private String customSecondLanguage;
 
     @Schema(description = "두 번째 언어 표시명", example = "베트남어")
@@ -80,13 +86,19 @@ public class UserProfileResponse {
     @Schema(description = "가족 구조", example = "TWO_PARENTS")
     private FamilyStructure familyStructure;
 
-    @Schema(description = "가족 구조 직접 입력값 (CUSTOM 시)", example = "조부모님과 살아요")
+    @Schema(
+            description = "가족 구조 직접 입력값 (CUSTOM 선택 시에만 반환, 일반 선택 시 null)",
+            nullable = true
+    )
     private String customFamilyStructure;
 
     @Schema(description = "이야기 선호도", example = "FUN_ADVENTURE")
     private StoryPreference storyPreference;
 
-    @Schema(description = "이야기 선호도 직접 입력값 (CUSTOM 시)", example = "우주 탐험 이야기")
+    @Schema(
+            description = "이야기 선호도 직접 입력값 (CUSTOM 선택 시에만 반환, 일반 선택 시 null)",
+            nullable = true
+    )
     private String customStoryPreference;
 
     @Schema(description = "아이 국적", example = "KR")

--- a/src/main/java/com/moretale/domain/profile/entity/Language.java
+++ b/src/main/java/com/moretale/domain/profile/entity/Language.java
@@ -9,21 +9,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Language {
 
-    KO("한국어", "ko"),
-    EN("영어", "en"),
-    JA("일본어", "ja"),
-    ZH("중국어", "zh"),
-    ES("스페인어", "es"),
-    VI("베트남어", "vi"),
-    OTHER("기타", null);
+    KO("한국어", "ko", "ko-KR"),
+    EN("영어",   "en", "en-US"),
+    JA("일본어", "ja", "ja-JP"),
+    ZH("중국어", "zh", "zh-CN"),
+    ES("스페인어","es", "es-ES"),
+    VI("베트남어","vi", "vi-VN"),
+    OTHER("기타", null, null);
 
     private final String description;
     private final String isoCode;
 
-    /**
-     * 하위 호환성: 기존 String 코드 → Language Enum 변환
-     * ex) "ko" → KO, "vi" → VI, 매핑 불가 시 OTHER 반환
-     */
+    // TTS locale 코드 (Google TTS / Azure 등에서 사용하는 BCP-47 형식)
+    // OTHER는 null → TTS 미지원 대상으로 처리
+    private final String ttsLocale;
+
+    // isoCode → Language Enum 변환
+    // 매핑 불가 시 OTHER 반환
     public static Language fromIsoCode(String isoCode) {
         if (isoCode == null) return OTHER;
         for (Language lang : values()) {
@@ -34,9 +36,27 @@ public enum Language {
         return OTHER;
     }
 
+    // ttsLocale → Language Enum 변환 (TTSService 검증용)
+    // 매핑 불가 시 OTHER 반환
+    public static Language fromTtsLocale(String ttsLocale) {
+        if (ttsLocale == null) return OTHER;
+        for (Language lang : values()) {
+            if (ttsLocale.equalsIgnoreCase(lang.ttsLocale)) {
+                return lang;
+            }
+        }
+        return OTHER;
+    }
+
+    // TTS 지원 여부 확인
+    // OTHER는 ttsLocale이 null이므로 false 반환
+    public boolean isTtsSupported() {
+        return this.ttsLocale != null;
+    }
+
     /**
-     * primary/secondary 동기화용: 실제 저장할 언어 코드 문자열 반환
-     * - OTHER면 customValue(직접 입력값)를 반환
+     * Legacy 동기화용: primaryLanguage / secondaryLanguage 저장값 반환
+     * - OTHER면 customValue(직접 입력값) 반환
      * - 그 외에는 name() 반환 (ex. "KO", "EN")
      */
     public String resolveCode(String customValue) {

--- a/src/main/java/com/moretale/domain/profile/util/LanguageLocaleMapper.java
+++ b/src/main/java/com/moretale/domain/profile/util/LanguageLocaleMapper.java
@@ -1,0 +1,58 @@
+package com.moretale.domain.profile.util;
+
+import com.moretale.domain.profile.entity.Language;
+import com.moretale.domain.profile.entity.UserProfile;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Language Enum ↔ TTS locale 변환 유틸
+ *
+ * StoryService, TTSService 등에서 locale 문자열 조합 대신 이 클래스를 통해 항상 올바른 BCP-47 locale 코드를 얻도록 한다.
+ *
+ * 사용 예시:
+ *   LanguageLocaleMapper.resolveTtsLocale(profile.getFirstLanguage(), null) → "ko-KR"
+ *   LanguageLocaleMapper.resolveTtsLocale(Language.VI, null) → "vi-VN"
+ *   LanguageLocaleMapper.resolveTtsLocale(Language.OTHER, "태국어") → null (TTS 미지원)
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LanguageLocaleMapper {
+
+    /**
+     * Language Enum → TTS locale 코드 반환
+     *
+     * @param language    Language Enum 값
+     * @param customValue OTHER 선택 시 사용자 직접 입력값 (그 외엔 무시됨)
+     * @return TTS locale 코드 (ex. "ko-KR", "vi-VN") 또는 null (OTHER / 미지원)
+     */
+    public static String resolveTtsLocale(Language language, String customValue) {
+        if (language == null || language == Language.OTHER) {
+            log.debug("TTS locale 변환 불가 - language={}, customValue={}", language, customValue);
+            return null;
+        }
+        return language.getTtsLocale();
+    }
+
+    // UserProfile의 첫 번째 언어 → TTS locale 반환
+    public static String resolvePrimaryTtsLocale(UserProfile profile) {
+        return resolveTtsLocale(profile.getFirstLanguage(), profile.getCustomFirstLanguage());
+    }
+
+    // UserProfile의 두 번째 언어 → TTS locale 반환
+    public static String resolveSecondaryTtsLocale(UserProfile profile) {
+        return resolveTtsLocale(profile.getSecondLanguage(), profile.getCustomSecondLanguage());
+    }
+
+    // TTS locale → Language Enum 역변환
+    // TTSService 검증 등에서 사용
+    public static Language fromTtsLocale(String ttsLocale) {
+        return Language.fromTtsLocale(ttsLocale);
+    }
+
+    // TTS 지원 여부 확인
+    public static boolean isTtsSupported(Language language) {
+        return language != null && language.isTtsSupported();
+    }
+}

--- a/src/main/java/com/moretale/domain/story/dto/RecentStoryResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/RecentStoryResponse.java
@@ -2,10 +2,7 @@ package com.moretale.domain.story.dto;
 
 import com.moretale.domain.story.entity.Story;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -26,18 +23,32 @@ public class RecentStoryResponse {
     private String childName;
 
     @Schema(
-            description = "제1언어 코드 또는 표시값 (예: ko, en, ja, 태국어)",
+            description = """
+                    [Legacy] 제1언어 ISO 코드 (ex. ko, vi, en).
+                    Story 저장 시 Profile.firstLanguage Enum의 isoCode를 기반으로 저장된 값.
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장되어 있을 수 있음.
+                    향후 firstLanguage / firstLanguageDisplay / primaryLanguageCode 필드로 분리 예정.
+                    """,
             example = "ko"
     )
     private String primaryLanguage;
 
     @Schema(
-            description = "제2언어 코드 또는 표시값 (예: en, vi, ja, 힌디어)",
-            example = "en"
+            description = """
+                    [Legacy] 제2언어 ISO 코드 (ex. vi, en, ja).
+                    Story 저장 시 Profile.secondLanguage Enum의 isoCode를 기반으로 저장된 값.
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장되어 있을 수 있음.
+                    향후 secondLanguage / secondLanguageDisplay / secondaryLanguageCode 필드로 분리 예정.
+                    """,
+            example = "vi"
     )
     private String secondaryLanguage;
 
-    @Schema(description = "썸네일 이미지 URL (첫 번째 슬라이드)", example = "https://storage.example.com/images/slide1.png")
+    @Schema(
+            description = "썸네일 이미지 URL (첫 번째 슬라이드 기준, 슬라이드가 없으면 null 가능)",
+            nullable = true,
+            example = "https://storage.example.com/images/slide1.png"
+    )
     private String thumbnailUrl;
 
     @Schema(description = "공개 여부", example = "false")

--- a/src/main/java/com/moretale/domain/story/dto/SlideResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/SlideResponse.java
@@ -37,10 +37,14 @@ public class SlideResponse {
     @Schema(description = "한국어 음성 URL", example = "https://storage.example.com/audio/slide1_kr.mp3")
     private String audioUrlKr;
 
-    @Schema(description = "제2언어 음성 URL", example = "https://storage.example.com/audio/slide1_vi.mp3")
+    @Schema(
+            description = "제2언어 음성 URL (TTS 미지원 언어 또는 OTHER 언어인 경우 null 가능)",
+            nullable = true,
+            example = "https://storage.example.com/audio/slide1_vi.mp3"
+    )
     private String audioUrlNative;
 
-    @Schema(description = "단어 토큰 목록 (하이라이트 단어)")
+    @Schema(description = "단어 토큰 목록 (하이라이트 단어 포함)")
     private List<TokenResponse> tokens;
 
     public static SlideResponse from(Slide slide) {

--- a/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
@@ -1,16 +1,8 @@
 package com.moretale.domain.story.dto;
 
-import com.moretale.domain.profile.entity.AgeGroup;
-import com.moretale.domain.profile.entity.FamilyStructure;
-import com.moretale.domain.profile.entity.LanguageProficiency;
-import com.moretale.domain.profile.entity.StoryPreference;
-import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.entity.*;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 // 온보딩 데이터 기반 동화 생성 초기값 응답 DTO
 // GET /api/stories/init 엔드포인트에서 사용
@@ -28,11 +20,22 @@ public class StoryInitResponse {
     @Schema(description = "주인공 아이 이름", example = "민준")
     private String childName;
 
-    @Schema(description = "제1언어 표시명", example = "한국어")
-    private String firstLanguage;
+    /**
+     * 제1언어 표시명 (UI 표시 전용)
+     * 필드명을 firstLanguageDisplay로 변경하여 display 값임을 명확히 함.
+     * 기존 firstLanguage 필드명은 value처럼 보여 혼동을 유발했음.
+     */
+    @Schema(
+            description = "제1언어 표시명 (UI 표시 전용, ex. 한국어, 베트남어, 태국어)",
+            example = "한국어"
+    )
+    private String firstLanguageDisplay;
 
-    @Schema(description = "제2언어 표시명", example = "베트남어")
-    private String secondLanguage;
+    @Schema(
+            description = "제2언어 표시명 (UI 표시 전용, ex. 베트남어, 영어)",
+            example = "베트남어"
+    )
+    private String secondLanguageDisplay;
 
     @Schema(description = "나이 그룹", example = "AGE_5_6")
     private AgeGroup ageGroup;
@@ -73,13 +76,13 @@ public class StoryInitResponse {
     @Schema(description = "추천 전래동화 제목", example = "흥부와 놀부")
     private String recommendedTaleTitle;
 
-    // UserProfile 엔티티로부터 초기값 생성
     public static StoryInitResponse from(UserProfile profile, String recommendedTale) {
         return StoryInitResponse.builder()
                 .profileId(profile.getProfileId())
                 .childName(profile.getChildName())
-                .firstLanguage(profile.getFirstLanguageDisplay())
-                .secondLanguage(profile.getSecondLanguageDisplay())
+                // display 값임을 명확히 하기 위해 필드명 변경
+                .firstLanguageDisplay(profile.getFirstLanguageDisplay())
+                .secondLanguageDisplay(profile.getSecondLanguageDisplay())
                 .ageGroup(profile.getAgeGroup())
                 .childAge(profile.getChildAge())
                 .firstLanguageProficiency(profile.getFirstLanguageProficiency())

--- a/src/main/java/com/moretale/domain/story/dto/StoryListResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryListResponse.java
@@ -2,11 +2,7 @@ package com.moretale.domain.story.dto;
 
 import com.moretale.domain.story.entity.Story;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -24,16 +20,34 @@ public class StoryListResponse {
     @Schema(description = "동화 제목", example = "흥부와 놀부")
     private String title;
 
-    @Schema(description = "썸네일 이미지 URL (첫 번째 슬라이드)", example = "https://storage.example.com/images/slide1.png")
+    @Schema(
+            description = "썸네일 이미지 URL (첫 번째 슬라이드 기준, 슬라이드가 없으면 null 가능)",
+            nullable = true,
+            example = "https://storage.example.com/images/slide1.png"
+    )
     private String thumbnail;
 
     @Schema(description = "주인공 아이 이름", example = "민준")
     private String childName;
 
-    @Schema(description = "제1언어 코드", example = "KO")
+    @Schema(
+            description = """
+                    [Legacy] 제1언어 ISO 코드 (ex. ko, vi, en).
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장될 수 있음.
+                    향후 firstLanguage / firstLanguageDisplay / primaryLanguageCode 필드로 분리 예정.
+                    """,
+            example = "ko"
+    )
     private String primaryLanguage;
 
-    @Schema(description = "제2언어 코드", example = "VI")
+    @Schema(
+            description = """
+                    [Legacy] 제2언어 ISO 코드 (ex. vi, en, ja).
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장될 수 있음.
+                    향후 secondLanguage / secondLanguageDisplay / secondaryLanguageCode 필드로 분리 예정.
+                    """,
+            example = "vi"
+    )
     private String secondaryLanguage;
 
     @Schema(description = "공개 여부", example = "false")

--- a/src/main/java/com/moretale/domain/story/dto/StoryResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryResponse.java
@@ -2,11 +2,7 @@ package com.moretale.domain.story.dto;
 
 import com.moretale.domain.story.entity.Story;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,10 +28,42 @@ public class StoryResponse {
     @Schema(description = "주인공 아이 이름", example = "민준")
     private String childName;
 
-    @Schema(description = "제1언어 코드", example = "KO")
+    /**
+     * ISO 코드 기반 언어 값 (ex. "ko", "vi", "en")
+     * Profile.firstLanguage(Enum)의 isoCode를 저장한 값.
+     * OTHER 언어인 경우 사용자가 입력한 custom 문자열이 저장될 수 있음.
+     *
+     * Story 계층 언어 구조 통합 완료 후
+     * firstLanguage / firstLanguageDisplay / primaryLanguageCode 로 분리 예정.
+     */
+    @Schema(
+            description = """
+                    [Legacy] 제1언어 ISO 코드 (ex. ko, vi, en).
+                    Profile.firstLanguage Enum의 isoCode 기반 저장값.
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장될 수 있음.
+                    향후 firstLanguage / firstLanguageDisplay / primaryLanguageCode 필드로 분리 예정.
+                    """,
+            example = "ko"
+    )
     private String primaryLanguage;
 
-    @Schema(description = "제2언어 코드", example = "VI")
+    /**
+     * ISO 코드 기반 언어 값 (ex. "vi", "en", "ja")
+     * Profile.secondLanguage(Enum)의 isoCode를 저장한 값.
+     * OTHER 언어인 경우 사용자가 입력한 custom 문자열이 저장될 수 있음.
+     *
+     * Story 계층 언어 구조 통합 완료 후
+     * secondLanguage / secondLanguageDisplay / secondaryLanguageCode 로 분리 예정.
+     */
+    @Schema(
+            description = """
+                    [Legacy] 제2언어 ISO 코드 (ex. vi, en, ja).
+                    Profile.secondLanguage Enum의 isoCode 기반 저장값.
+                    OTHER인 경우 사용자 입력 custom 문자열이 저장될 수 있음.
+                    향후 secondLanguage / secondLanguageDisplay / secondaryLanguageCode 필드로 분리 예정.
+                    """,
+            example = "en"
+    )
     private String secondaryLanguage;
 
     @Schema(description = "공개 여부", example = "false")

--- a/src/main/java/com/moretale/domain/story/dto/TokenResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/TokenResponse.java
@@ -1,12 +1,14 @@
 package com.moretale.domain.story.dto;
 
 import com.moretale.domain.story.entity.StoryToken;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "동화 단어 토큰 응답 DTO")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -14,28 +16,44 @@ import lombok.Setter;
 @Builder
 public class TokenResponse {
 
-    // 토큰 고정 ID (단어 저장 시 사용될 식별자)
+    @Schema(description = "토큰 고유 ID (단어 저장 시 사용될 식별자)", example = "242")
     private Long id;
 
-    // 원문 단어 텍스트 (정규화된 형태, 예: "사자")
+    @Schema(description = "원문 단어 텍스트 (정규화된 형태)", example = "사자")
     private String text;
 
-    // 하이라이트 여부
+    @Schema(description = "하이라이트 여부", example = "true")
     private Boolean highlight;
 
-    // 번역어 (highlight=true인 경우에만 존재)
+    @Schema(
+            description = "번역어 (highlight=true인 경우에만 반환, highlight=false이면 null)",
+            nullable = true,
+            example = "lion"
+    )
     private String translation;
 
-    // 뜻 설명 (highlight=true인 경우에만 존재)
+    @Schema(
+            description = "뜻 설명 (highlight=true인 경우에만 반환, highlight=false이면 null)",
+            nullable = true,
+            example = "사자에 대한 설명입니다."
+    )
     private String definition;
 
-    // 단어 발음 오디오 URL (highlight=true인 경우에만 존재)
+    @Schema(
+            description = "단어 발음 오디오 URL (highlight=true인 경우에만 반환, highlight=false이면 null)",
+            nullable = true,
+            example = "https://storage.moretale.ai/tts/token-ko-KR.mp3"
+    )
     private String audioUrl;
 
-    // 원문 언어 코드 (예: "ko")
+    @Schema(description = "원문 언어 ISO 코드", example = "ko")
     private String sourceLanguage;
 
-    // 번역 언어 코드 (예: "ja", "vi" 등 / highlight=true인 경우에만 존재)
+    @Schema(
+            description = "번역 언어 ISO 코드 (highlight=true인 경우에만 반환, highlight=false이면 null)",
+            nullable = true,
+            example = "en"
+    )
     private String targetLanguage;
 
     /**

--- a/src/main/java/com/moretale/domain/story/service/StoryService.java
+++ b/src/main/java/com/moretale/domain/story/service/StoryService.java
@@ -4,6 +4,7 @@ import com.moretale.domain.profile.entity.Language;
 import com.moretale.domain.profile.entity.StoryPreference;
 import com.moretale.domain.profile.entity.UserProfile;
 import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.profile.util.LanguageLocaleMapper;
 import com.moretale.domain.story.dto.StoryGenerateRequest;
 import com.moretale.domain.story.dto.StoryGenerateResponse;
 import com.moretale.domain.story.dto.StoryInitResponse;
@@ -167,22 +168,24 @@ public class StoryService {
                 request
         );
 
-        // TTS 생성
+        // TTS locale 생성 로직 개선
+        String primaryLocale = LanguageLocaleMapper.resolvePrimaryTtsLocale(profile);
+        String secondaryLocale = LanguageLocaleMapper.resolveSecondaryTtsLocale(profile);
         response.getSlides().forEach(slide -> {
             try {
-                if (slide.getTextKr() != null) {
+                if (slide.getTextKr() != null && primaryLocale != null) {
                     slide.setAudioUrlKr(
-                            ttsService.generateTTS(slide.getTextKr(), primaryLang + "-KR")
+                            ttsService.generateTTS(slide.getTextKr(), primaryLocale)
                     );
+                } else if (slide.getTextKr() != null) {
+                    log.info("첫 번째 언어 TTS 미지원 - slideOrder={}", slide.getOrder());
                 }
 
-                if (slide.getTextNative() != null) {
+                if (slide.getTextNative() != null && secondaryLocale != null) {
                     slide.setAudioUrlNative(
-                            ttsService.generateTTS(
-                                    slide.getTextNative(),
-                                    secondaryLang + "-" + secondaryLang.toUpperCase()
-                            )
-                    );
+                            ttsService.generateTTS(slide.getTextNative(), secondaryLocale)                    );
+                } else if (slide.getTextNative() != null) {
+                    log.info("두 번째 언어 TTS 미지원 - slideOrder={}", slide.getOrder());
                 }
             } catch (Exception e) {
                 log.error("TTS 생성 중 오류 발생 (건너뜀) - slideOrder={}",
@@ -317,7 +320,7 @@ public class StoryService {
         storyRepository.delete(story);
     }
 
-    // userId로 사용자 조회 (email 기반 조회 제거)
+    // userId로 사용자 조회
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/moretale/domain/tts/service/TTSService.java
+++ b/src/main/java/com/moretale/domain/tts/service/TTSService.java
@@ -1,24 +1,39 @@
 package com.moretale.domain.tts.service;
 
+import com.moretale.domain.profile.entity.Language;
 import com.moretale.domain.tts.dto.TTSRequest;
 import com.moretale.domain.tts.dto.TTSResponse;
 import com.moretale.global.exception.BusinessException;
 import com.moretale.global.exception.ErrorCode;
 
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public interface TTSService {
 
     // TTS 생성
     TTSResponse generateTTS(TTSRequest request);
 
-    // 텍스트 + 언어 코드로 오디오 URL 생성 (내부 사용)
+    // 텍스트 + locale 코드로 오디오 URL 생성 (StoryService 내부 사용)
     String generateAudioUrl(String text, String language);
 
-    // 언어 코드 유효성 검증 (ko-KR, vi-VN, en-US)
+    /**
+     * TTS locale 유효성 검증
+     *
+     * Language Enum의 ttsLocale 값을 기반으로 지원 여부 판단.
+     * Swagger 문서의 지원 예시와 실제 검증 로직을 Language Enum 단일 소스로 일치시킴.
+     *
+     * 지원: ko-KR, en-US, ja-JP, zh-CN, es-ES, vi-VN
+     * 미지원: OTHER, null, 알 수 없는 코드
+     */
     default void validateLanguage(String language) {
-        Set<String> supportedLanguages = Set.of("ko-KR", "vi-VN", "en-US");
-        if (!supportedLanguages.contains(language)) {
+        Set<String> supportedLocales = Arrays.stream(Language.values())
+                .filter(Language::isTtsSupported)
+                .map(Language::getTtsLocale)
+                .collect(Collectors.toSet());
+
+        if (language == null || !supportedLocales.contains(language)) {
             throw new BusinessException(ErrorCode.TTS_INVALID_LANGUAGE);
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #54
- close #55

## ✨ 작업 내용 요약
- `Story/TTS` 계층의 언어 처리 구조를 `Language Enum` 기반으로 정리
- `Language Enum`에 `isoCode` 및 TTS locale(`BCP-47`) 매핑 구조 추가
- `LanguageLocaleMapper` 유틸 추가 및 `StoryService` TTS locale 생성 로직 개선
- `TTSService` validate 로직을 `Language Enum` 기반 지원 locale 구조로 통일
- Swagger 문서와 실제 응답/Validation 구조 차이점 점검 및 정리
- `StoryResponse` / `StoryListResponse` / `RecentStoryResponse`의 legacy 언어 필드 설명 보완
- `SlideResponse` / `TokenResponse`의 nullable 및 조건부 반환 필드 설명 추가
- `LanguageUpdateRequest` 및 `UserProfileResponse`의 `OTHER/custom` 입력 규칙 Swagger 예시 수정
- `StoryInitResponse`의 display 전용 언어 필드명 명확화

## 🗒️ 참고 사항
- 현재 Story 계층은 legacy 문자열 기반(`primaryLanguage`, `secondaryLanguage`) 구조와 Enum 기반 구조가 공존하는 상태
- `primaryLanguage` / `secondaryLanguage`는 추후 `firstLanguageDisplay`, `languageCode` 계열 필드로 점진적 분리 예정
- `OTHER` 언어는 현재 TTS 미지원 대상으로 처리됨
- `TokenResponse.translation` / `definition` / `audioUrl` / `targetLanguage`는 `highlight=true`인 경우에만 반환됨
- Swagger Example과 실제 Service 동작 기준이 일치하는지 검증 완료
- `ko-KR` / `ja-JP` / `zh-CN` / `es-ES` / `vi-VN` locale 생성 동작 확인 완료