### PR TITLE
Chore/25-env-secrets-separation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# =============================================
+# MoreTale Backend 환경변수 설정 템플릿
+# 이 파일을 복사하여 .env 로 만들고 값을 채우세요.
+# cp .env.example .env
+# =============================================
+
+# 서버 설정
+PORT=8080
+SPRING_PROFILES_ACTIVE=local
+
+# 데이터베이스 설정
+DB_URL=jdbc:postgresql://localhost:5432/moretale
+DB_USERNAME=postgres
+DB_PASSWORD=your_db_password_here
+
+# Google OAuth2
+GOOGLE_CLIENT_ID=your_google_client_id_here
+GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+
+# JWT 설정 (최소 256비트, 32자 이상 랜덤 문자열 권장)
+JWT_SECRET=your_jwt_secret_minimum_32_characters_long_random_string
+
+# 파일 업로드 경로 (선택 - 기본값 사용 가능)
+# FILE_UPLOAD_PATH=/home/user/moretale/uploads
+# FILE_BASE_URL=http://localhost:8080/uploads
+
+# AI 서비스 연동 URL (선택 - 기본값 사용 가능)
+# STORY_GENERATION_URL=http://localhost:8081
+# IMAGE_GENERATION_URL=http://localhost:8082
+# TTS_URL=http://localhost:8083
+# QUIZ_GENERATION_URL=http://localhost:8084
+
+# Google Cloud Storage (운영 환경)
+# GCS_BUCKET=moretale-audio-bucket
+# GCP_CREDENTIALS_PATH=classpath:gcp-service-account.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ Thumbs.db
 
 # 환경 파일
 .env
+application-local.yml
+
+# Google Cloud Credentials
+gcp-service-account.json
+**/gcp-service-account.json
 
 # Copilot local config
 .github/copilot-instructions.md

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,0 +1,28 @@
+# =============================================
+# 이 파일을 복사하여 application-local.yml 로 만드세요.
+# cp src/main/resources/application-local.yml.example \
+#    src/main/resources/application-local.yml
+#
+# ⚠️  application-local.yml은 .gitignore에 포함되어 있습니다.
+#
+# 실제 민감값(.env)은 루트의 .env 파일에 넣으세요.
+# 참고: .env.example
+# =============================================
+
+spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
+
+logging:
+  level:
+    com.moretale: debug
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+# =============================================
+# 운영 환경 전용 오버라이드 (Render / GCP / Docker)
+# 민감값은 없고 환경변수 참조만 사용
+# =============================================
+
+spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    root: warn
+    com.moretale: info
+    org.hibernate.SQL: warn
+    org.hibernate.orm.jdbc.bind: warn

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,12 +3,16 @@ server:
 
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # .env 파일 자동 로드 (로컬 개발용, 운영에서는 무시됨)
+  config:
+    import: optional:file:.env[.properties]
 
   # 데이터베이스 설정
   datasource:
-    url: jdbc:postgresql://localhost:5432/moretale
-    username: postgres
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/moretale}
+    username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
@@ -17,18 +21,11 @@ spring:
     hibernate:
       ddl-auto: update
     defer-datasource-initialization: true
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
-
-  # SQL 초기화 설정
-  sql:
-    init:
-      mode: always
-      encoding: UTF-8
 
   # OAuth2 보안 설정
   security:
@@ -87,29 +84,11 @@ moretale:
 google:
   cloud:
     storage:
-      bucket: moretale-audio-bucket
+      bucket: ${GCS_BUCKET:moretale-audio-bucket}
       base-url: https://storage.googleapis.com
     credentials:
-      location: classpath:gcp-service-account.json
+      location: ${GCP_CREDENTIALS_PATH:classpath:gcp-service-account.json}
 
----
-# prod 프로필 (Docker / GCP 환경)
-spring:
-  config:
-    activate:
-      on-profile: prod
-
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: false
-
-  sql:
-    init:
-      mode: never
+logging:
+  level:
+    root: info


### PR DESCRIPTION
## 📌 관련 이슈
- close #57

## ✨ 작업 내용 요약
- application.yml의 공통 설정 구조를 정리하고 profile 기반(local/prod) 환경 분리 적용
- Spring Boot에서 `.env` 파일을 자동 로드하도록 설정 추가 (`spring.config.import`)
- local / prod 환경별 override 설정 파일 추가
  - `application-local.yml.example`
  - `application-prod.yml`
- datasource, OAuth2, JWT 등의 민감 설정을 환경변수 기반 구조로 통일
- `.env.example` 추가 및 로컬 실행용 환경변수 템플릿 구성
- `.gitignore`에 `.env`, `application-local.yml`, GCP credential 파일 추가
- Hibernate SQL 로그 출력 구조 개선
  - `show-sql` 제거
  - `org.hibernate.SQL` logger 기반 출력으로 통일
- local 환경에서는 SQL debug/trace 로그 활성화, prod 환경에서는 warn 수준으로 분리

## 🗒️ 참고 사항
- Render / GCP / Docker 환경에서는 플랫폼 환경변수를 통해 값 주입 예정
- `application-local.yml`은 로컬 전용 설정 파일이며 `.gitignore`에 포함됨
- 실행 시 active profile은 `.env`의 `SPRING_PROFILES_ACTIVE` 값 기준으로 동작
- `.env` 자동 로드를 위해 `spring.config.import=optional:file:.env[.properties]` 적용