### PR TITLE
fix/api-link-cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ JWT_SECRET=moretale_local_jwt_secret_minimum_64_characters_long_for_hs512_dev
 # 프론트엔드 리다이렉트 URL
 FRONTEND_URL=http://localhost:8080
 
+# 프론트엔드 CORS 허용 Origin
+MORETALE_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
 # 파일 업로드 경로 (선택 - 기본값 사용 가능)
 # FILE_UPLOAD_PATH=/home/user/moretale/uploads
 # FILE_BASE_URL=http://localhost:8080/uploads

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     // Database
     runtimeOnly 'org.postgresql:postgresql'
-    implementation 'com.google.cloud.sql:postgres-socket-factory:1.21.0'
+    implementation 'com.google.cloud.sql:postgres-socket-factory:1.28.3'
 
     // Google Cloud Services (Storage & TTS)
     implementation 'com.google.cloud:google-cloud-storage:2.36.1'

--- a/src/main/java/com/moretale/global/config/MoreTaleProperties.java
+++ b/src/main/java/com/moretale/global/config/MoreTaleProperties.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // 프로젝트 전역 설정 프로퍼티 클래스
 @Configuration
 @ConfigurationProperties(prefix = "moretale")
@@ -15,6 +18,7 @@ public class MoreTaleProperties {
     private Ai ai = new Ai(); // AI 관련 설정 (동화/이미지 생성)
     private Tts tts = new Tts(); // TTS 관련 설정 (음성 변환 API)
     private Quiz quiz = new Quiz(); // 퀴즈 관련 설정 (자동 생성 API)
+    private Cors cors = new Cors(); // 프론트엔드 CORS 허용 origin 설정
 
     // AI 생성 모델 관련 API 주소 설정
     @Getter
@@ -46,5 +50,12 @@ public class MoreTaleProperties {
     @Setter
     public static class Quiz {
         private String autoGenerationUrl;
+    }
+
+    // 프론트엔드 CORS 허용 origin 설정
+    @Getter
+    @Setter
+    public static class Cors {
+        private List<String> allowedOrigins = new ArrayList<>();
     }
 }

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -2,12 +2,16 @@ package com.moretale.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moretale.global.common.ApiResponse;
+import com.moretale.global.config.MoreTaleProperties;
 import com.moretale.global.security.jwt.JwtAuthenticationFilter;
 import com.moretale.global.security.oauth.CustomOAuth2UserService;
 import com.moretale.global.security.oauth.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -15,8 +19,14 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -27,16 +37,19 @@ public class SecurityConfig {
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final ObjectMapper objectMapper;
+    private final MoreTaleProperties moreTaleProperties;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                         // 로그인 없이 접근 가능
                         .requestMatchers(
                                 "/", "/login",
@@ -139,5 +152,36 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(resolveAllowedOrigins());
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilterRegistration(CorsConfigurationSource corsConfigurationSource) {
+        FilterRegistrationBean<CorsFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new CorsFilter(corsConfigurationSource));
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+
+    private List<String> resolveAllowedOrigins() {
+        return moreTaleProperties.getCors().getAllowedOrigins().stream()
+                .flatMap(origin -> Arrays.stream(origin.split(",")))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,8 @@ tts:
 
 # MoreTale AI 서비스 연동 설정
 moretale:
+  cors:
+    allowed-origins: ${MORETALE_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
   ai:
     base-url: ${MORETALE_AI_BASE_URL:${STORY_GENERATION_URL:http://localhost:8081}}
     api-key: ${MORETALE_AI_API_KEY:}


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용 요약
- Vercel 프론트엔드 연동을 위한 CORS 설정 구조 개선
- `MoreTaleProperties`에 CORS 허용 origin 설정 추가
- `SecurityConfig`에 `CorsConfigurationSource` 및 `CorsFilter` 등록
- Spring Security에서 preflight(OPTIONS) 요청이 인증 전에 처리되도록 수정
- `allowed-origins` 환경변수 기반 설정 구조 추가
- Cloud SQL PostgreSQL Socket Factory 의존성 버전 업데이트 (`1.21.0 → 1.28.3`)
- `.env.example`에 CORS 환경변수 예시 추가

## 🗒️ 참고 사항
- 기존 `FRONTEND_URL` 기반 OAuth redirect 구조는 유지