### PR TITLE
Feat/27-story-init-response

### DIFF
--- a/src/main/java/com/moretale/domain/story/controller/StoryController.java
+++ b/src/main/java/com/moretale/domain/story/controller/StoryController.java
@@ -38,6 +38,8 @@ public class StoryController {
                     - ageGroup / childAge : 연령 그룹
                     - storyPreference : 이야기 선호도
                     - recommendedTaleTitle : 추천 전래동화 제목
+                    - storyId : 추천 전래동화와 일치하는 가장 최근 생성 동화 ID (없으면 null)
+                    - coverImageUrl : 추천 전래동화와 일치하는 가장 최근 생성 동화의 표지 이미지 URL (없으면 null)
                     """
     )
     @GetMapping("/init")

--- a/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
+++ b/src/main/java/com/moretale/domain/story/dto/StoryInitResponse.java
@@ -76,11 +76,49 @@ public class StoryInitResponse {
     @Schema(description = "추천 전래동화 제목", example = "흥부와 놀부")
     private String recommendedTaleTitle;
 
+    /**
+     * 추천 전래동화와 일치하는 가장 최근 생성된 동화 ID
+     *
+     * - recommendedTaleTitle과 같은 title을 가진 동화 중 가장 최근 것
+     * - profile_id 컬럼 추가 이전 데이터는 userId + title 기반 fallback으로 조회
+     * - 해당 추천 동화를 아직 생성한 적이 없으면 null
+     */
+    @Schema(
+            description = "추천 전래동화와 일치하는 가장 최근 생성된 동화 ID (없으면 null)",
+            nullable = true,
+            example = "42"
+    )
+    private Long storyId;
+
+    /**
+     * 추천 전래동화와 일치하는 가장 최근 생성된 동화의 표지 이미지 URL
+     *
+     * - recommendedTaleTitle과 같은 title을 가진 동화 기준
+     * - 첫 번째 슬라이드(order=0)의 imageUrl 기준
+     * - 해당 추천 동화를 아직 생성한 적이 없거나 슬라이드가 없으면 null
+     */
+    @Schema(
+            description = "추천 전래동화와 일치하는 가장 최근 생성된 동화의 표지 이미지 URL (첫 번째 슬라이드 기준, 없으면 null)",
+            nullable = true,
+            example = "https://storage.example.com/images/slide1.png"
+    )
+    private String coverImageUrl;
+
+    // 기존 from() - 하위 호환 유지 (storyId, coverImageUrl = null)
     public static StoryInitResponse from(UserProfile profile, String recommendedTale) {
+        return from(profile, recommendedTale, null, null);
+    }
+
+    // storyId, coverImageUrl 포함
+    public static StoryInitResponse from(
+            UserProfile profile,
+            String recommendedTale,
+            Long storyId,
+            String coverImageUrl
+    ) {
         return StoryInitResponse.builder()
                 .profileId(profile.getProfileId())
                 .childName(profile.getChildName())
-                // display 값임을 명확히 하기 위해 필드명 변경
                 .firstLanguageDisplay(profile.getFirstLanguageDisplay())
                 .secondLanguageDisplay(profile.getSecondLanguageDisplay())
                 .ageGroup(profile.getAgeGroup())
@@ -96,6 +134,8 @@ public class StoryInitResponse {
                 .familyStructure(profile.getFamilyStructure())
                 .customFamilyStructure(profile.getCustomFamilyStructure())
                 .recommendedTaleTitle(recommendedTale)
+                .storyId(storyId)
+                .coverImageUrl(coverImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/moretale/domain/story/entity/Story.java
+++ b/src/main/java/com/moretale/domain/story/entity/Story.java
@@ -56,6 +56,9 @@ public class Story {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "profile_id")
+    private Long profileId;
+
     @Column(name = "child_name", length = 100)
     private String childName;
 

--- a/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
@@ -112,11 +112,46 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     Page<Story> findPublicStories(Pageable pageable);
 
     /**
+     * /api/stories/init 용 - recommendedTaleTitle 기준 조회
+     *
+     * profileId + title 기반으로 추천 전래동화와 일치하는 가장 최근 storyId 1건 조회
+     * - profile_id 컬럼 추가 이후 저장된 데이터 대상
+     * - 결과 없으면 Service에서 userId + title 기반 fallback 호출
+     */
+    @Query("""
+        SELECT s.storyId FROM Story s
+        WHERE s.user.userId = :userId
+          AND s.profileId = :profileId
+          AND s.title = :title
+        ORDER BY s.createdAt DESC
+    """)
+    List<Long> findLatestStoryIdByProfileAndTitle(
+            @Param("userId") Long userId,
+            @Param("profileId") Long profileId,
+            @Param("title") String title,
+            Pageable pageable
+    );
+
+    /**
+     * /api/stories/init 용 — fallback (profile_id = NULL 기존 데이터 대응)
+     *
+     * userId + title 기반으로 추천 전래동화와 일치하는 가장 최근 storyId 1건 조회
+     * findLatestStoryIdByProfileAndTitle() 결과가 비어있을 때만 호출
+     */
+    @Query("""
+        SELECT s.storyId FROM Story s
+        WHERE s.user.userId = :userId
+          AND s.title = :title
+        ORDER BY s.createdAt DESC
+    """)
+    List<Long> findLatestStoryIdByUserAndTitle(
+            @Param("userId") Long userId,
+            @Param("title") String title,
+            Pageable pageable
+    );
+
+    /**
      * 기존 메서드 - 사용하지 않지만 하위 호환을 위해 유지
-     *
-     * 주의: Pageable + fetch join 조합으로 메모리 페이징 발생 (HHH90003004)
-     * 도서관 목록 조회에는 findIdsByUserId + fetchByIdsWithSlides 방식 사용 권장
-     *
      * @deprecated LibraryService.getLibrary()에서 더 이상 사용하지 않음
      */
     @Deprecated

--- a/src/main/java/com/moretale/domain/story/service/StoryService.java
+++ b/src/main/java/com/moretale/domain/story/service/StoryService.java
@@ -25,6 +25,8 @@ import com.moretale.global.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,10 +64,47 @@ public class StoryService {
             recommendedTale = TraditionalTale.findByPreference(profile.getStoryPreference());
         }
 
-        log.info("동화 초기값 조회 - userId={}, profileId={}, 추천 전래동화={}",
-                userId, profile.getProfileId(), recommendedTale.getTitle());
+        // recommendedTaleTitle과 일치하는 동화 기준으로 storyId + coverImageUrl 조회
+        //
+        // init API는 온보딩 추천 전래동화 기반이므로
+        // storyId / coverImageUrl도 recommendedTaleTitle과 같은 동화여야 의미가 맞음
+        //
+        // [1차] profileId + title 기반 정확 조회
+        // [2차] profile_id = NULL 기존 데이터 fallback (userId + title 기반)
+        Pageable latestOne = PageRequest.of(0, 1);
+        String recommendedTitle = recommendedTale.getTitle();
 
-        return StoryInitResponse.from(profile, recommendedTale.getTitle());
+        List<Long> storyIds = storyRepository.findLatestStoryIdByProfileAndTitle(
+                userId, profile.getProfileId(), recommendedTitle, latestOne
+        );
+
+        if (storyIds.isEmpty()) {
+            storyIds = storyRepository.findLatestStoryIdByUserAndTitle(
+                    userId, recommendedTitle, latestOne
+            );
+        }
+
+        Long resolvedStoryId = null;
+        String coverImageUrl = null;
+
+        if (!storyIds.isEmpty()) {
+            resolvedStoryId = storyIds.get(0);
+
+            List<Story> stories = storyRepository.fetchByIdsWithSlides(storyIds);
+            if (!stories.isEmpty() && !stories.get(0).getSlides().isEmpty()) {
+                coverImageUrl = stories.get(0).getSlides().get(0).getImageUrl();
+            }
+        }
+
+        log.info("동화 초기값 조회 - userId={}, profileId={}, 추천 전래동화={}, storyId={}",
+                userId, profile.getProfileId(), recommendedTitle, resolvedStoryId);
+
+        return StoryInitResponse.from(
+                profile,
+                recommendedTitle,
+                resolvedStoryId,
+                coverImageUrl
+        );
     }
 
     // 비동기 동화 생성 작업 등록
@@ -139,6 +178,7 @@ public class StoryService {
                 .title(request.getTitle())
                 .prompt(request.getPrompt())
                 .user(user)
+                .profileId(request.getProfileId())
                 .childName(profile.getChildName())
                 .primaryLanguage(resolvePrimaryLanguage(profile))
                 .secondaryLanguage(resolveSecondaryLanguage(profile))

--- a/src/main/java/com/moretale/global/security/SecurityConfig.java
+++ b/src/main/java/com/moretale/global/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.moretale.global.security.jwt.JwtAuthenticationFilter;
 import com.moretale.global.security.oauth.CustomOAuth2UserService;
 import com.moretale.global.security.oauth.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -170,7 +171,9 @@ public class SecurityConfig {
     }
 
     @Bean
-    public FilterRegistrationBean<CorsFilter> corsFilterRegistration(CorsConfigurationSource corsConfigurationSource) {
+    public FilterRegistrationBean<CorsFilter> corsFilterRegistration(
+            @Qualifier("corsConfigurationSource") CorsConfigurationSource corsConfigurationSource
+    ) {
         FilterRegistrationBean<CorsFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(new CorsFilter(corsConfigurationSource));
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE);


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용 요약
- `/api/stories/init` 응답에 `storyId`, `coverImageUrl` 필드 추가
- `StoryInitResponse` DTO 확장 및 Swagger Schema 설명 보완
- `Story` 엔티티에 `profileId` 필드 추가 및 동화 저장 시 프로필 정보 저장
- 추천 전래동화(`recommendedTaleTitle`)와 일치하는 최근 생성 동화를 조회하도록 로직 개선
- `StoryRepository`에 추천 동화 기준 최신 동화 조회 쿼리 추가
  - `profileId + title` 기반 조회
  - 기존 데이터 대응을 위한 `userId + title` fallback 조회
- `/api/stories/init` API 문서에 `storyId`, `coverImageUrl` 응답 필드 설명 추가
- `SecurityConfig`에서 `CorsConfigurationSource` 빈 주입 충돌 문제 수정
  - `@Qualifier("corsConfigurationSource")` 적용

## 🗒️ 참고 사항
- `storyId`와 `coverImageUrl`은 현재 프로필의 추천 전래동화와 동일한 제목의 동화 중 가장 최근 생성된 데이터를 기준으로 반환된다.
- 사용자가 해당 추천 전래동화를 생성한 이력이 없는 경우 `storyId`, `coverImageUrl`은 `null`로 반환
- 기존 `StoryInitResponse.from(profile, recommendedTale)` 메서드는 하위 호환을 위해 유지 + 신규 오버로드 메서드를 추가하여 확장
- `profile_id` 컬럼 추가 이전에 저장된 동화 데이터도 조회할 수 있도록 fallback 로직을 포함
- Swagger 응답 예시와 실제 응답 구조 일치 확인 완료