### PR TITLE
Refactor/28-profile-story-fk

### DIFF
--- a/src/main/java/com/moretale/domain/story/entity/Story.java
+++ b/src/main/java/com/moretale/domain/story/entity/Story.java
@@ -1,9 +1,12 @@
 package com.moretale.domain.story.entity;
 
+import com.moretale.domain.profile.entity.UserProfile;
 import com.moretale.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -56,8 +59,11 @@ public class Story {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "profile_id")
-    private Long profileId;
+    // profile 삭제 시 연관된 story도 함께 삭제
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private UserProfile profile;
 
     @Column(name = "child_name", length = 100)
     private String childName;

--- a/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/moretale/domain/story/repository/StoryRepository.java
@@ -113,15 +113,12 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
 
     /**
      * /api/stories/init 용 - recommendedTaleTitle 기준 조회
-     *
-     * profileId + title 기반으로 추천 전래동화와 일치하는 가장 최근 storyId 1건 조회
-     * - profile_id 컬럼 추가 이후 저장된 데이터 대상
-     * - 결과 없으면 Service에서 userId + title 기반 fallback 호출
+     * profile 객체의 profileId로 조회 (s.profileId → s.profile.profileId)
      */
     @Query("""
         SELECT s.storyId FROM Story s
         WHERE s.user.userId = :userId
-          AND s.profileId = :profileId
+          AND s.profile.profileId = :profileId
           AND s.title = :title
         ORDER BY s.createdAt DESC
     """)

--- a/src/main/java/com/moretale/domain/story/service/LibraryService.java
+++ b/src/main/java/com/moretale/domain/story/service/LibraryService.java
@@ -3,9 +3,6 @@ package com.moretale.domain.story.service;
 import com.moretale.domain.story.dto.StoryLibraryCardResponse;
 import com.moretale.domain.story.entity.Story;
 import com.moretale.domain.story.repository.StoryRepository;
-import com.moretale.domain.user.entity.User;
-import com.moretale.domain.user.repository.UserRepository;
-import com.moretale.domain.vocabulary.repository.VocabularyEntryRepository;
 import com.moretale.global.exception.BusinessException;
 import com.moretale.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +22,8 @@ import java.util.stream.Collectors;
 
 /**
  * 도서관 전용 서비스
- * - 도서관 = 사용자가 생성한 동화 자체를 관리하는 영역
- * - 삭제 = 동화 자체 삭제 (숨김 아님)
- * - 삭제 시 Story → Slide → StoryToken → VocabularyEntry 순으로 연쇄 삭제 로직 포함
+ * - vocabulary_entries는 @OnDelete(CASCADE)로 DB 레벨에서 자동 삭제되므로
+ *   별도 vocabularyEntryRepository.deleteAllByStory() 호출 불필요
  */
 @Slf4j
 @Service
@@ -36,8 +32,6 @@ import java.util.stream.Collectors;
 public class LibraryService {
 
     private final StoryRepository storyRepository;
-    private final UserRepository userRepository;
-    private final VocabularyEntryRepository vocabularyEntryRepository;
 
     /**
      * 도서관 목록 조회 (페이징 + 정렬) — N+1 및 메모리 페이징 개선 버전
@@ -88,7 +82,7 @@ public class LibraryService {
                 .collect(Collectors.toMap(Story::getStoryId, Function.identity()));
 
         List<StoryLibraryCardResponse> content = ids.stream()
-                .filter(storyMap::containsKey)          // 혹시 모를 누락 방어
+                .filter(storyMap::containsKey)
                 .map(id -> StoryLibraryCardResponse.from(storyMap.get(id)))
                 .collect(Collectors.toList());
 
@@ -98,35 +92,24 @@ public class LibraryService {
 
     /**
      * 도서관에서 동화 삭제
-     * - Story 삭제 시 외래 키 제약 조건(VocabularyEntry 참조)을 해결하기 위해 자식 데이터를 먼저 삭제합니다.
-     *
-     * @param userId  인증된 사용자 ID
-     * @param storyId 삭제할 동화 ID
+     * - vocabulary_entries: @OnDelete(CASCADE)로 DB 레벨 자동 삭제
+     * - slides, story_tokens: JPA CascadeType.ALL + orphanRemoval로 자동 삭제
      */
     @Transactional
     public void deleteFromLibrary(Long userId, Long storyId) {
         Story story = storyRepository.findByStoryIdAndUserId(storyId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
 
-        // 외래 키 제약 조건 위반 방지를 위해 관련 단어장 데이터를 먼저 삭제
-        vocabularyEntryRepository.deleteAllByStory(story);
-
-        // 동화 삭제 (JPA Cascade에 의해 Slide, StoryToken이 함께 삭제됨)
         storyRepository.delete(story);
 
-        log.info("도서관 동화 및 관련 단어장 데이터 완전 삭제 완료 - userId={}, storyId={}, title={}",
+        log.info("도서관 동화 삭제 완료 - userId={}, storyId={}, title={}",
                 userId, storyId, story.getTitle());
     }
 
-    /**
-     * 정렬 필드 화이트리스트 검증
-     * - 허용 필드: createdAt, title
-     * - 허용되지 않은 필드 → 기본값(createdAt DESC)으로 대체하여 SQL Injection 방지
-     */
     private Pageable buildSafePageable(Pageable pageable) {
         Sort sort = pageable.getSort();
 
-        // Sort가 없거나 비어있으면 기본값 적용 [cite: 265]
+        // Sort가 없거나 비어있으면 기본값 적용
         if (sort.isUnsorted()) {
             return PageRequest.of(
                     pageable.getPageNumber(),
@@ -135,7 +118,7 @@ public class LibraryService {
             );
         }
 
-        // 허용 필드 외 정렬 필드 제거 후 재구성 [cite: 266, 267]
+        // 허용 필드 외 정렬 필드 제거 후 재구성
         Sort safeSort = Sort.by(
                 sort.stream()
                         .filter(order -> isAllowedSortField(order.getProperty()))
@@ -145,7 +128,7 @@ public class LibraryService {
                         .toList()
         );
 
-        // 모든 정렬 필드가 거부된 경우 기본값 사용 [cite: 268, 269]
+        // 모든 정렬 필드가 거부된 경우 기본값 사용
         if (safeSort.isUnsorted()) {
             safeSort = Sort.by(Sort.Direction.DESC, "createdAt");
         }
@@ -155,10 +138,5 @@ public class LibraryService {
 
     private boolean isAllowedSortField(String field) {
         return "createdAt".equals(field) || "title".equals(field);
-    }
-
-    private User getUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/moretale/domain/story/service/StoryService.java
+++ b/src/main/java/com/moretale/domain/story/service/StoryService.java
@@ -178,7 +178,7 @@ public class StoryService {
                 .title(request.getTitle())
                 .prompt(request.getPrompt())
                 .user(user)
-                .profileId(request.getProfileId())
+                .profile(profile)
                 .childName(profile.getChildName())
                 .primaryLanguage(resolvePrimaryLanguage(profile))
                 .secondaryLanguage(resolveSecondaryLanguage(profile))


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용 요약
- Story 엔티티의 `profileId(Long)` 필드를 `UserProfile` 연관관계로 변경
- Story와 UserProfile 간 FK 관계를 적용하여 프로필 삭제 시 관련 동화가 함께 삭제되도록 개선
- Story 저장 로직을 profileId 기반 저장 방식에서 UserProfile 엔티티 저장 방식으로 변경
- StoryRepository 조회 로직을 `profile.profileId` 기반으로 수정
- `/api/stories/init` 추천 동화 조회 시 profile 연관관계 기반 조회가 가능하도록 쿼리 개선
- LibraryService 내 사용되지 않는 UserRepository 의존성과 관련 코드를 제거하여 코드 정리

## 🗒️ 참고 사항
- 기존 `HoneyJarHistory.storyId(Long)` 구조는 유지, Story와의 FK 연관관계는 적용X
- 기존 데이터 중 `profile_id`가 NULL인 동화가 존재할 수 있어 `profile_id` 컬럼에는 아직 `nullable = false`를 적용X
- UserProfile 삭제 시 Story → Slide → StoryToken 순으로 연관 데이터 함께 삭제