### PR TITLE
Test/31-core-user-flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy MoreTale Backend
 on:
   push:
     branches:
-      - develop
+      - main
 
 env:
   PROJECT_ID: project-640335ef-3b09-441e-a26

--- a/README.md
+++ b/README.md
@@ -378,7 +378,9 @@ MoreTale-backend
 │   │       └── data.sql
 │   │
 │   └── test
-│       └── java
+│       ├── domain
+│       ├── support
+│       └── resources
 │
 ├── .env (not included in github repo)
 ├── build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.mockito:mockito-core'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/test/java/com/moretale/domain/honeyjar/entity/HoneyJarTest.java
+++ b/src/test/java/com/moretale/domain/honeyjar/entity/HoneyJarTest.java
@@ -1,0 +1,82 @@
+package com.moretale.domain.honeyjar.entity;
+
+import com.moretale.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("HoneyJar 엔티티 단위 테스트")
+class HoneyJarTest {
+
+    private HoneyJar buildHoneyJar(int count) {
+        return HoneyJar.builder()
+                .user(User.builder().userId(1L).build())
+                .count(count)
+                .totalEarned(count)
+                .totalUsed(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("add() - count, totalEarned 증가")
+    void add_increasesCountAndTotalEarned() {
+        HoneyJar honeyJar = buildHoneyJar(3);
+        honeyJar.add(2);
+
+        assertThat(honeyJar.getCount()).isEqualTo(5);
+        assertThat(honeyJar.getTotalEarned()).isEqualTo(5);
+        assertThat(honeyJar.getTotalUsed()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("use() - 잔액 충분 시 차감 성공 → true")
+    void use_sufficientBalance_returnsTrue() {
+        HoneyJar honeyJar = buildHoneyJar(10);
+        boolean result = honeyJar.use(10);
+
+        assertThat(result).isTrue();
+        assertThat(honeyJar.getCount()).isEqualTo(0);
+        assertThat(honeyJar.getTotalUsed()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("use() - 잔액 부족 시 차감 실패 → false")
+    void use_insufficientBalance_returnsFalse() {
+        HoneyJar honeyJar = buildHoneyJar(5);
+        boolean result = honeyJar.use(10);
+
+        assertThat(result).isFalse();
+        assertThat(honeyJar.getCount()).isEqualTo(5); // 변화 없음
+        assertThat(honeyJar.getTotalUsed()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("canGenerateFree() - 10개 이상 시 true")
+    void canGenerateFree_tenOrMore_returnsTrue() {
+        assertThat(buildHoneyJar(10).canGenerateFree()).isTrue();
+        assertThat(buildHoneyJar(11).canGenerateFree()).isTrue();
+    }
+
+    @Test
+    @DisplayName("canGenerateFree() - 9개 이하 시 false")
+    void canGenerateFree_belowTen_returnsFalse() {
+        assertThat(buildHoneyJar(9).canGenerateFree()).isFalse();
+        assertThat(buildHoneyJar(0).canGenerateFree()).isFalse();
+    }
+
+    @Test
+    @DisplayName("9개 → +1 → 10개 달성 → use(10) → 0개")
+    void scenario_add9_add1_reach10_use10() {
+        HoneyJar honeyJar = buildHoneyJar(9);
+        honeyJar.add(1);
+
+        assertThat(honeyJar.canGenerateFree()).isTrue();
+
+        boolean used = honeyJar.use(10);
+        assertThat(used).isTrue();
+        assertThat(honeyJar.getCount()).isEqualTo(0);
+        assertThat(honeyJar.getTotalEarned()).isEqualTo(10);
+        assertThat(honeyJar.getTotalUsed()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/moretale/domain/honeyjar/service/HoneyJarServiceTest.java
+++ b/src/test/java/com/moretale/domain/honeyjar/service/HoneyJarServiceTest.java
@@ -1,0 +1,218 @@
+package com.moretale.domain.honeyjar.service;
+
+import com.moretale.domain.honeyjar.dto.HoneyJarResponse;
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.honeyjar.entity.HoneyJarAction;
+import com.moretale.domain.honeyjar.entity.HoneyJarHistory;
+import com.moretale.domain.honeyjar.repository.HoneyJarHistoryRepository;
+import com.moretale.domain.honeyjar.repository.HoneyJarRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HoneyJarService 단위 테스트")
+class HoneyJarServiceTest {
+
+    @Mock HoneyJarRepository honeyJarRepository;
+    @Mock HoneyJarHistoryRepository honeyJarHistoryRepository;
+    @Mock UserRepository userRepository;
+
+    @InjectMocks HoneyJarService honeyJarService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L)
+                .email("test@example.com")
+                .nickname("홍길동")
+                .role(User.Role.USER)
+                .build();
+    }
+
+    // ────────────────── getHoneyJar ──────────────────
+
+    @Test
+    @DisplayName("꿀단지 조회 - 기존 레코드 있음")
+    void getHoneyJar_existingRecord() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .honeyJarId(1L)
+                .user(testUser)
+                .count(5)
+                .totalEarned(7)
+                .totalUsed(2)
+                .build();
+
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.of(honeyJar));
+
+        HoneyJarResponse response = honeyJarService.getHoneyJar(testUser);
+
+        assertThat(response.getCount()).isEqualTo(5);
+        assertThat(response.getTotalEarned()).isEqualTo(7);
+        assertThat(response.getTotalUsed()).isEqualTo(2);
+        assertThat(response.getCanGenerateFree()).isFalse();
+        assertThat(response.getRemainingForFree()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("꿀단지 조회 - 레코드 없으면 신규 생성")
+    void getHoneyJar_noRecord_createNew() {
+        HoneyJar newHoneyJar = HoneyJar.builder()
+                .honeyJarId(1L)
+                .user(testUser)
+                .count(0)
+                .totalEarned(0)
+                .totalUsed(0)
+                .build();
+
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.empty());
+        given(honeyJarRepository.save(any(HoneyJar.class))).willReturn(newHoneyJar);
+
+        HoneyJarResponse response = honeyJarService.getHoneyJar(testUser);
+
+        assertThat(response.getCount()).isEqualTo(0);
+        assertThat(response.getRemainingForFree()).isEqualTo(10);
+        verify(honeyJarRepository).save(any(HoneyJar.class));
+    }
+
+    @Test
+    @DisplayName("꿀단지 10개 이상 - canGenerateFree = true")
+    void getHoneyJar_tenOrMore_canGenerateFreeTrue() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser)
+                .count(10)
+                .totalEarned(10)
+                .totalUsed(0)
+                .build();
+
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.of(honeyJar));
+
+        HoneyJarResponse response = honeyJarService.getHoneyJar(testUser);
+
+        assertThat(response.getCanGenerateFree()).isTrue();
+        assertThat(response.getRemainingForFree()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("꿀단지 조회 - userId 기반")
+    void getHoneyJarByUserId_success() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(3).totalEarned(3).totalUsed(0).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.of(honeyJar));
+
+        HoneyJarResponse response = honeyJarService.getHoneyJarByUserId(1L);
+
+        assertThat(response.getCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("꿀단지 조회 - userId 없음 → USER_NOT_FOUND")
+    void getHoneyJarByUserId_userNotFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> honeyJarService.getHoneyJarByUserId(99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    // ────────────────── addHoneyJarAndCheckAutoUse ──────────────────
+
+    @Test
+    @DisplayName("꿀단지 지급 - 9개 → 10개 미달, 자동차감 없음")
+    void addHoneyJar_belowThreshold_noAutoUse() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(8).totalEarned(8).totalUsed(0).build();
+
+        given(honeyJarRepository.findByUserWithLock(testUser)).willReturn(Optional.of(honeyJar));
+        given(honeyJarRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarHistoryRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        boolean autoUsed = honeyJarService.addHoneyJarAndCheckAutoUse(
+                testUser, HoneyJarAction.EARN_STORY_COMPLETE, 1L);
+
+        assertThat(autoUsed).isFalse();
+        assertThat(honeyJar.getCount()).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("꿀단지 지급 - 9개 → 10개 달성, 자동차감 발생")
+    void addHoneyJar_reachesThreshold_autoUse() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(9).totalEarned(9).totalUsed(0).build();
+
+        given(honeyJarRepository.findByUserWithLock(testUser)).willReturn(Optional.of(honeyJar));
+        given(honeyJarRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarHistoryRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        boolean autoUsed = honeyJarService.addHoneyJarAndCheckAutoUse(
+                testUser, HoneyJarAction.EARN_STORY_COMPLETE, 1L);
+
+        assertThat(autoUsed).isTrue();
+        // 10개 달성 후 10개 차감 → 0개
+        assertThat(honeyJar.getCount()).isEqualTo(0);
+        // 이력 저장 2번 (지급 + 차감)
+        verify(honeyJarHistoryRepository, times(2)).save(any(HoneyJarHistory.class));
+    }
+
+    @Test
+    @DisplayName("꿀단지 지급 - 레코드 없으면 신규 생성 후 지급")
+    void addHoneyJar_noRecord_createAndAdd() {
+        HoneyJar newHoneyJar = HoneyJar.builder()
+                .user(testUser).count(0).totalEarned(0).totalUsed(0).build();
+
+        given(honeyJarRepository.findByUserWithLock(testUser)).willReturn(Optional.empty());
+        given(honeyJarRepository.save(any())).willAnswer(inv -> {
+            HoneyJar arg = inv.getArgument(0);
+            return arg;
+        });
+        given(honeyJarHistoryRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        boolean autoUsed = honeyJarService.addHoneyJarAndCheckAutoUse(
+                testUser, HoneyJarAction.EARN_QUIZ_PERFECT, 5L);
+
+        assertThat(autoUsed).isFalse();
+        verify(honeyJarRepository, atLeast(1)).save(any(HoneyJar.class));
+    }
+
+    @Test
+    @DisplayName("꿀단지 이력 조회 - 최신순 반환")
+    void getHoneyJarHistory_returnsList() {
+        HoneyJarHistory h1 = HoneyJarHistory.builder()
+                .user(testUser).actionType(HoneyJarAction.EARN_STORY_COMPLETE)
+                .amount(1).reason("완독").balanceAfter(1).build();
+        HoneyJarHistory h2 = HoneyJarHistory.builder()
+                .user(testUser).actionType(HoneyJarAction.EARN_QUIZ_PERFECT)
+                .amount(1).reason("퀴즈").balanceAfter(2).build();
+
+        given(honeyJarHistoryRepository.findByUserOrderByCreatedAtDesc(testUser))
+                .willReturn(List.of(h2, h1));
+
+        var result = honeyJarService.getHoneyJarHistory(testUser);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getActionType())
+                .isEqualTo(HoneyJarAction.EARN_QUIZ_PERFECT.name());
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/controller/UserProfileControllerIntegrationTest.java
+++ b/src/test/java/com/moretale/domain/profile/controller/UserProfileControllerIntegrationTest.java
@@ -1,0 +1,233 @@
+package com.moretale.domain.profile.controller;
+
+import com.moretale.domain.profile.dto.OnboardingProfileRequest;
+import com.moretale.domain.profile.dto.LanguageUpdateRequest;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import com.moretale.support.IntegrationTestSupport;
+import com.moretale.support.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("UserProfile Controller 통합 테스트")
+class UserProfileControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired UserRepository userRepository;
+    @Autowired UserProfileRepository userProfileRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(TestFixture.createUser("profile-test@example.com"));
+        setAuthentication(testUser);
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - 정상 요청 → 201 + 응답 구조 검증")
+    void createOnboardingProfile_success() throws Exception {
+        OnboardingProfileRequest request = buildValidOnboardingRequest();
+
+        perform(post("/api/users/profile/onboarding")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.childName").value("민준"))
+                .andExpect(jsonPath("$.data.profileId").exists())
+                .andExpect(jsonPath("$.data.firstLanguage").value("KO"))
+                .andExpect(jsonPath("$.data.secondLanguage").value("VI"))
+                .andExpect(jsonPath("$.message").value("프로필 설정이 완료되었습니다!"));
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - OTHER 언어 + custom → 정상 저장")
+    void createOnboardingProfile_otherLanguage() throws Exception {
+        OnboardingProfileRequest request = buildValidOnboardingRequest();
+        request.setFirstLanguage(Language.OTHER);
+        request.setCustomFirstLanguage("태국어");
+
+        perform(post("/api/users/profile/onboarding")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.firstLanguage").value("OTHER"))
+                .andExpect(jsonPath("$.data.customFirstLanguage").value("태국어"))
+                .andExpect(jsonPath("$.data.firstLanguageDisplay").value("태국어"));
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - OTHER 언어 + custom 누락 → 400 VALIDATION_ERROR")
+    void createOnboardingProfile_otherWithoutCustom_400() throws Exception {
+        OnboardingProfileRequest request = buildValidOnboardingRequest();
+        request.setFirstLanguage(Language.OTHER);
+        request.setCustomFirstLanguage(null);
+
+        perform(post("/api/users/profile/onboarding")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.data.customFirstLanguage").exists());
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - childName 누락 → 400")
+    void createOnboardingProfile_missingChildName_400() throws Exception {
+        OnboardingProfileRequest request = buildValidOnboardingRequest();
+        request.setChildName(null);
+
+        perform(post("/api/users/profile/onboarding")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.data.childName").exists());
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - 동일 이름 중복 등록 → 409")
+    void createOnboardingProfile_duplicate_409() throws Exception {
+        UserProfile existing = TestFixture.createProfile(testUser);
+        userProfileRepository.save(existing);
+
+        OnboardingProfileRequest request = buildValidOnboardingRequest();
+
+        perform(post("/api/users/profile/onboarding")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("P003"));
+    }
+
+    @Test
+    @DisplayName("전체 프로필 목록 조회 - 정상")
+    void getAllProfiles_success() throws Exception {
+        userProfileRepository.save(TestFixture.createProfile(testUser));
+
+        perform(get("/api/users/profile/list"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(greaterThanOrEqualTo(1))))
+                .andExpect(jsonPath("$.data[0].childName").value("민준"));
+    }
+
+    @Test
+    @DisplayName("언어 설정 수정 - 정상")
+    void updateLanguage_success() throws Exception {
+        UserProfile saved = userProfileRepository.save(TestFixture.createProfile(testUser));
+
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.EN)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.JA)
+                .customSecondLanguage(null)
+                .build();
+
+        perform(patch("/api/users/profile/" + saved.getProfileId() + "/language")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.firstLanguage").value("EN"))
+                .andExpect(jsonPath("$.data.secondLanguage").value("JA"))
+                .andExpect(jsonPath("$.message").value("언어 설정이 변경되었습니다."));
+    }
+
+    @Test
+    @DisplayName("언어 설정 수정 - OTHER 선택 + custom 없음 → 현재 구현 기준 실패")
+    void updateLanguage_otherWithoutCustom_validationFail() throws Exception {
+
+        UserProfile saved =
+                userProfileRepository.save(TestFixture.createProfile(testUser));
+
+        LanguageUpdateRequest request =
+                LanguageUpdateRequest.builder()
+                        .firstLanguage(Language.OTHER)
+                        .customFirstLanguage(null)
+                        .secondLanguage(Language.VI)
+                        .customSecondLanguage(null)
+                        .build();
+
+        perform(
+                patch("/api/users/profile/" + saved.getProfileId() + "/language")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        )
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("프로필 존재 여부 - 프로필 있음 → true")
+    void hasProfile_returnsTrue() throws Exception {
+        userProfileRepository.save(TestFixture.createProfile(testUser));
+
+        perform(get("/api/users/profile/exists"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    @DisplayName("프로필 존재 여부 - 프로필 없음 → false")
+    void hasProfile_returnsFalse() throws Exception {
+        perform(get("/api/users/profile/exists"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(false));
+    }
+
+    @Test
+    @DisplayName("프로필 삭제 - 정상")
+    void deleteProfile_success() throws Exception {
+        UserProfile saved = userProfileRepository.save(TestFixture.createProfile(testUser));
+
+        perform(delete("/api/users/profile/" + saved.getProfileId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("프로필이 삭제되었습니다."));
+    }
+
+    private ResultActions perform(
+            org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder builder)
+            throws Exception {
+        return mockMvc.perform(builder).andDo(print());
+    }
+
+    private void setAuthentication(User user) {
+        UserPrincipal principal = UserPrincipal.create(user);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities()));
+    }
+
+    private OnboardingProfileRequest buildValidOnboardingRequest() {
+        return OnboardingProfileRequest.builder()
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .customFamilyStructure(null)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .customStoryPreference(null)
+                .build();
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/dto/LanguageUpdateRequestValidationTest.java
+++ b/src/test/java/com/moretale/domain/profile/dto/LanguageUpdateRequestValidationTest.java
@@ -1,0 +1,116 @@
+package com.moretale.domain.profile.dto;
+
+import com.moretale.domain.profile.entity.Language;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("LanguageUpdateRequest Validation 테스트")
+class LanguageUpdateRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("일반 언어 정상 입력 - 검증 통과")
+    void valid_normalLanguages() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .build();
+        Set<ConstraintViolation<LanguageUpdateRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("OTHER + custom 있음 - 검증 통과")
+    void valid_otherWithCustom() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("태국어")
+                .build();
+        Set<ConstraintViolation<LanguageUpdateRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("firstLanguage null - 검증 실패")
+    void invalid_firstLanguageNull() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(null)
+                .secondLanguage(Language.VI)
+                .build();
+        Set<ConstraintViolation<LanguageUpdateRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("firstLanguage"));
+    }
+
+    @Test
+    @DisplayName("secondLanguage null - 검증 실패")
+    void invalid_secondLanguageNull() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .secondLanguage(null)
+                .build();
+        Set<ConstraintViolation<LanguageUpdateRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("secondLanguage"));
+    }
+
+    @Test
+    @DisplayName("OTHER + custom null - validate() 예외 발생")
+    void invalid_otherWithoutCustom_validateThrows() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .build();
+        assertThatThrownBy(request::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("기타");
+    }
+
+    @Test
+    @DisplayName("secondLanguage=OTHER + custom blank - validate() 예외 발생")
+    void invalid_secondOtherWithBlankCustom_validateThrows() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("   ")
+                .build();
+        assertThatThrownBy(request::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("기타");
+    }
+
+    @Test
+    @DisplayName("customSecondLanguage 100자 초과 - 검증 실패")
+    void invalid_customSecondLanguageTooLong() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("a".repeat(101))
+                .build();
+        Set<ConstraintViolation<LanguageUpdateRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customSecondLanguage"));
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/dto/OnboardingProfileRequestValidationTest.java
+++ b/src/test/java/com/moretale/domain/profile/dto/OnboardingProfileRequestValidationTest.java
@@ -1,0 +1,247 @@
+package com.moretale.domain.profile.dto;
+
+import com.moretale.domain.profile.entity.*;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OnboardingProfileRequest Validation 테스트")
+class OnboardingProfileRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("정상 입력 (일반 언어) - 검증 통과")
+    void valid_normalLanguage() {
+        OnboardingProfileRequest request = validBuilder().build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정상 입력 (OTHER 언어 + custom 값) - 검증 통과")
+    void valid_otherLanguageWithCustom() {
+        OnboardingProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage("태국어")
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("힌디어")
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CUSTOM familyStructure + customFamilyStructure 있음 - 검증 통과")
+    void valid_customFamilyStructure() {
+        OnboardingProfileRequest request = validBuilder()
+                .familyStructure(FamilyStructure.CUSTOM)
+                .customFamilyStructure("조부모님과 살아요")
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CUSTOM storyPreference + customStoryPreference 있음 - 검증 통과")
+    void valid_customStoryPreference() {
+        OnboardingProfileRequest request = validBuilder()
+                .storyPreference(StoryPreference.CUSTOM)
+                .customStoryPreference("우주 탐험 이야기")
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("childName null - 검증 실패")
+    void invalid_childNameNull() {
+        OnboardingProfileRequest request = validBuilder().childName(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("childName"));
+    }
+
+    @Test
+    @DisplayName("childName blank - 검증 실패")
+    void invalid_childNameBlank() {
+        OnboardingProfileRequest request = validBuilder().childName("   ").build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("childName"));
+    }
+
+    @Test
+    @DisplayName("ageGroup null - 검증 실패")
+    void invalid_ageGroupNull() {
+        OnboardingProfileRequest request = validBuilder().ageGroup(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("ageGroup"));
+    }
+
+    @Test
+    @DisplayName("firstLanguage null - 검증 실패")
+    void invalid_firstLanguageNull() {
+        OnboardingProfileRequest request = validBuilder().firstLanguage(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("firstLanguage"));
+    }
+
+    @Test
+    @DisplayName("secondLanguage null - 검증 실패")
+    void invalid_secondLanguageNull() {
+        OnboardingProfileRequest request = validBuilder().secondLanguage(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("secondLanguage"));
+    }
+
+    @Test
+    @DisplayName("firstLanguageProficiency null - 검증 실패")
+    void invalid_firstLanguageProficiencyNull() {
+        OnboardingProfileRequest request = validBuilder().firstLanguageProficiency(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("firstLanguageProficiency"));
+    }
+
+    @Test
+    @DisplayName("familyStructure null - 검증 실패")
+    void invalid_familyStructureNull() {
+        OnboardingProfileRequest request = validBuilder().familyStructure(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("familyStructure"));
+    }
+
+    @Test
+    @DisplayName("storyPreference null - 검증 실패")
+    void invalid_storyPreferenceNull() {
+        OnboardingProfileRequest request = validBuilder().storyPreference(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("storyPreference"));
+    }
+
+    @Test
+    @DisplayName("firstLanguage=OTHER + customFirstLanguage null - 검증 실패")
+    void invalid_otherFirstLanguageWithoutCustom() {
+        OnboardingProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage(null)
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFirstLanguage"));
+    }
+
+    @Test
+    @DisplayName("firstLanguage=OTHER + customFirstLanguage blank - 검증 실패")
+    void invalid_otherFirstLanguageWithBlankCustom() {
+        OnboardingProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage("   ")
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFirstLanguage"));
+    }
+
+    @Test
+    @DisplayName("secondLanguage=OTHER + customSecondLanguage null - 검증 실패")
+    void invalid_otherSecondLanguageWithoutCustom() {
+        OnboardingProfileRequest request = validBuilder()
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage(null)
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customSecondLanguage"));
+    }
+
+    @Test
+    @DisplayName("familyStructure=CUSTOM + customFamilyStructure null - 검증 실패")
+    void invalid_customFamilyStructureWithoutValue() {
+        OnboardingProfileRequest request = validBuilder()
+                .familyStructure(FamilyStructure.CUSTOM)
+                .customFamilyStructure(null)
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFamilyStructure"));
+    }
+
+    @Test
+    @DisplayName("storyPreference=CUSTOM + customStoryPreference null - 검증 실패")
+    void invalid_customStoryPreferenceWithoutValue() {
+        OnboardingProfileRequest request = validBuilder()
+                .storyPreference(StoryPreference.CUSTOM)
+                .customStoryPreference(null)
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customStoryPreference"));
+    }
+
+    @Test
+    @DisplayName("childName null - 에러 메시지 확인")
+    void errorMessage_childNameNull() {
+        OnboardingProfileRequest request = validBuilder().childName(null).build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals("childName")
+                        && v.getMessage().equals("아이 이름은 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("OTHER + custom 누락 - 에러 메시지 확인")
+    void errorMessage_otherLanguageWithoutCustom() {
+        OnboardingProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage(null)
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals("customFirstLanguage")
+                        && v.getMessage().contains("기타"));
+    }
+
+    @Test
+    @DisplayName("childName 50자 초과 - 검증 실패")
+    void invalid_childNameTooLong() {
+        OnboardingProfileRequest request = validBuilder()
+                .childName("a".repeat(51))
+                .build();
+        Set<ConstraintViolation<OnboardingProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("childName"));
+    }
+
+    private OnboardingProfileRequest.OnboardingProfileRequestBuilder validBuilder() {
+        return OnboardingProfileRequest.builder()
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .customFamilyStructure(null)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .customStoryPreference(null);
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/dto/UserProfileRequestValidationTest.java
+++ b/src/test/java/com/moretale/domain/profile/dto/UserProfileRequestValidationTest.java
@@ -1,0 +1,162 @@
+package com.moretale.domain.profile.dto;
+
+import com.moretale.domain.profile.entity.*;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("UserProfileRequest Validation 테스트")
+class UserProfileRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("정상 입력 - 검증 통과")
+    void valid_normalInput() {
+        UserProfileRequest request = validBuilder().build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("OTHER 언어 + custom 값 정상 입력 - 검증 통과")
+    void valid_otherLanguageWithCustom() {
+        UserProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage("태국어")
+                .build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("childName null - 검증 실패")
+    void invalid_childNameNull() {
+        UserProfileRequest request = validBuilder().childName(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("childName"));
+    }
+
+    @Test
+    @DisplayName("firstLanguage null - 검증 실패")
+    void invalid_firstLanguageNull() {
+        UserProfileRequest request = validBuilder().firstLanguage(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("firstLanguage"));
+    }
+
+    @Test
+    @DisplayName("secondLanguage null - 검증 실패")
+    void invalid_secondLanguageNull() {
+        UserProfileRequest request = validBuilder().secondLanguage(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("secondLanguage"));
+    }
+
+    @Test
+    @DisplayName("firstLanguageProficiency null - 검증 실패")
+    void invalid_firstLanguageProficiencyNull() {
+        UserProfileRequest request = validBuilder().firstLanguageProficiency(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("firstLanguageProficiency"));
+    }
+
+    @Test
+    @DisplayName("ageGroup null - 검증 실패")
+    void invalid_ageGroupNull() {
+        UserProfileRequest request = validBuilder().ageGroup(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("ageGroup"));
+    }
+
+    @Test
+    @DisplayName("firstLanguage=OTHER + customFirstLanguage null - 검증 실패")
+    void invalid_otherLanguageWithoutCustom() {
+        UserProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage(null)
+                .build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFirstLanguage"));
+    }
+
+    @Test
+    @DisplayName("familyStructure=CUSTOM + customFamilyStructure null - 검증 실패")
+    void invalid_customFamilyStructureNull() {
+        UserProfileRequest request = validBuilder()
+                .familyStructure(FamilyStructure.CUSTOM)
+                .customFamilyStructure(null)
+                .build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFamilyStructure"));
+    }
+
+    @Test
+    @DisplayName("storyPreference=CUSTOM + customStoryPreference null - 검증 실패")
+    void invalid_customStoryPreferenceNull() {
+        UserProfileRequest request = validBuilder()
+                .storyPreference(StoryPreference.CUSTOM)
+                .customStoryPreference(null)
+                .build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customStoryPreference"));
+    }
+
+    @Test
+    @DisplayName("customFirstLanguage 100자 초과 - 검증 실패")
+    void invalid_customFirstLanguageTooLong() {
+        UserProfileRequest request = validBuilder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage("a".repeat(101))
+                .build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("customFirstLanguage"));
+    }
+
+    @Test
+    @DisplayName("familyStructure null - 검증 실패")
+    void invalid_familyStructureNull() {
+        UserProfileRequest request = validBuilder().familyStructure(null).build();
+        Set<ConstraintViolation<UserProfileRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("familyStructure"));
+    }
+
+    private UserProfileRequest.UserProfileRequestBuilder validBuilder() {
+        return UserProfileRequest.builder()
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .customFamilyStructure(null)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .customStoryPreference(null);
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/entity/LanguageEntityTest.java
+++ b/src/test/java/com/moretale/domain/profile/entity/LanguageEntityTest.java
@@ -1,0 +1,109 @@
+package com.moretale.domain.profile.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Language Enum 단위 테스트")
+class LanguageEntityTest {
+
+    // ────────────────── resolveCode ──────────────────
+
+    @ParameterizedTest(name = "language={0} → resolveCode={1}")
+    @CsvSource({
+            "KO,  KO",
+            "EN,  EN",
+            "VI,  VI",
+            "JA,  JA",
+            "ZH,  ZH",
+            "ES,  ES",
+    })
+    @DisplayName("resolveCode - 일반 언어는 name() 반환")
+    void resolveCode_normalLanguage(String langStr, String expected) {
+        Language lang = Language.valueOf(langStr);
+        assertThat(lang.resolveCode(null)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("resolveCode - OTHER + custom 값 있으면 custom 반환")
+    void resolveCode_other_withCustom() {
+        assertThat(Language.OTHER.resolveCode("태국어")).isEqualTo("태국어");
+    }
+
+    @Test
+    @DisplayName("resolveCode - OTHER + null → OTHER 문자열 반환")
+    void resolveCode_other_nullCustom() {
+        assertThat(Language.OTHER.resolveCode(null)).isEqualTo("OTHER");
+    }
+
+    // ────────────────── fromIsoCode ──────────────────
+
+    @ParameterizedTest(name = "isoCode={0} → {1}")
+    @CsvSource({
+            "ko, KO",
+            "en, EN",
+            "vi, VI",
+            "ja, JA",
+            "zh, ZH",
+            "es, ES",
+            "KO, KO",  // 대소문자 무관
+    })
+    @DisplayName("fromIsoCode - ISO 코드로 Enum 변환")
+    void fromIsoCode_success(String isoCode, String expected) {
+        assertThat(Language.fromIsoCode(isoCode)).isEqualTo(Language.valueOf(expected));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"unknown", "th", "xx"})
+    @DisplayName("fromIsoCode - 매핑 안 되면 OTHER 반환")
+    void fromIsoCode_unknown_returnsOther(String isoCode) {
+        assertThat(Language.fromIsoCode(isoCode)).isEqualTo(Language.OTHER);
+    }
+
+    // ────────────────── isTtsSupported ──────────────────
+
+    @ParameterizedTest(name = "{0} → ttsSupported={1}")
+    @CsvSource({
+            "KO, true",
+            "EN, true",
+            "VI, true",
+            "JA, true",
+            "ZH, true",
+            "ES, true",
+            "OTHER, false",
+    })
+    @DisplayName("isTtsSupported - OTHER만 false")
+    void isTtsSupported(String langStr, boolean expected) {
+        Language lang = Language.valueOf(langStr);
+        assertThat(lang.isTtsSupported()).isEqualTo(expected);
+    }
+
+    // ────────────────── ttsLocale ──────────────────
+
+    @ParameterizedTest(name = "{0} → ttsLocale={1}")
+    @CsvSource({
+            "KO, ko-KR",
+            "EN, en-US",
+            "VI, vi-VN",
+            "JA, ja-JP",
+            "ZH, zh-CN",
+            "ES, es-ES",
+    })
+    @DisplayName("ttsLocale - 각 언어별 BCP-47 코드 검증")
+    void ttsLocale_perLanguage(String langStr, String expectedLocale) {
+        Language lang = Language.valueOf(langStr);
+        assertThat(lang.getTtsLocale()).isEqualTo(expectedLocale);
+    }
+
+    @Test
+    @DisplayName("ttsLocale - OTHER는 null")
+    void ttsLocale_other_isNull() {
+        assertThat(Language.OTHER.getTtsLocale()).isNull();
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/entity/UserProfileEntityTest.java
+++ b/src/test/java/com/moretale/domain/profile/entity/UserProfileEntityTest.java
@@ -1,0 +1,204 @@
+package com.moretale.domain.profile.entity;
+
+import com.moretale.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("UserProfile 엔티티 비즈니스 로직 테스트")
+class UserProfileEntityTest {
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder().userId(1L).email("test@example.com").build();
+    }
+
+    // ────────────────── calculateChildAge (@PrePersist/@PreUpdate) ──────────────────
+
+    @Test
+    @DisplayName("calculateChildAge - ageGroup으로 childAge 자동 계산")
+    void calculateChildAge_setsRepresentativeAge() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.calculateChildAge();
+
+        assertThat(profile.getChildAge()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("calculateChildAge - AGE_0_2 → childAge = 1")
+    void calculateChildAge_age0to2() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_0_2);
+        profile.calculateChildAge();
+
+        assertThat(profile.getChildAge()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("calculateChildAge - 각 ageGroup 대표값 매핑 전체 검증")
+    void calculateChildAge_allAgeGroups() {
+        assertThat(AgeGroup.AGE_0_2.getRepresentativeAge()).isEqualTo(1);
+        assertThat(AgeGroup.AGE_3_4.getRepresentativeAge()).isEqualTo(3);
+        assertThat(AgeGroup.AGE_5_6.getRepresentativeAge()).isEqualTo(5);
+        assertThat(AgeGroup.AGE_7_8.getRepresentativeAge()).isEqualTo(7);
+        assertThat(AgeGroup.AGE_9_10.getRepresentativeAge()).isEqualTo(9);
+        assertThat(AgeGroup.AGE_10_PLUS.getRepresentativeAge()).isEqualTo(10);
+    }
+
+    // ────────────────── syncLegacyLanguages ──────────────────
+
+    @Test
+    @DisplayName("syncLegacyLanguages - KO → primaryLanguage = KO")
+    void sync_normalEnum_setsName() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.KO);
+        profile.setCustomFirstLanguage(null);
+        profile.setSecondLanguage(Language.VI);
+        profile.setCustomSecondLanguage(null);
+        profile.syncLegacyLanguages();
+
+        assertThat(profile.getPrimaryLanguage()).isEqualTo("KO");
+        assertThat(profile.getSecondaryLanguage()).isEqualTo("VI");
+    }
+
+    @Test
+    @DisplayName("syncLegacyLanguages - OTHER + custom → primaryLanguage = custom 값")
+    void sync_other_setsCustomValue() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage("태국어");
+        profile.setSecondLanguage(Language.OTHER);
+        profile.setCustomSecondLanguage("힌디어");
+        profile.syncLegacyLanguages();
+
+        assertThat(profile.getPrimaryLanguage()).isEqualTo("태국어");
+        assertThat(profile.getSecondaryLanguage()).isEqualTo("힌디어");
+    }
+
+    @Test
+    @DisplayName("syncLegacyLanguages - OTHER + null custom → OTHER 문자열 저장")
+    void sync_other_nullCustom_storesOtherString() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage(null);
+        profile.syncLegacyLanguages();
+
+        assertThat(profile.getPrimaryLanguage()).isEqualTo("OTHER");
+    }
+
+    // ────────────────── getFirstLanguageDisplay ──────────────────
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - 각 Enum 값 표시명 검증")
+    void getFirstLanguageDisplay_allLanguages() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+
+        profile.setFirstLanguage(Language.KO);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("한국어");
+
+        profile.setFirstLanguage(Language.EN);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("영어");
+
+        profile.setFirstLanguage(Language.VI);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("베트남어");
+
+        profile.setFirstLanguage(Language.JA);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("일본어");
+
+        profile.setFirstLanguage(Language.ZH);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("중국어");
+
+        profile.setFirstLanguage(Language.ES);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("스페인어");
+    }
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - OTHER + custom → custom 값 반환")
+    void getFirstLanguageDisplay_other_returnsCustom() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage("태국어");
+
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("태국어");
+    }
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - OTHER + null → 기타")
+    void getFirstLanguageDisplay_other_nullCustom_returnsDefault() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage(null);
+
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("기타");
+    }
+
+    // ────────────────── updateProfile ──────────────────
+
+    @Test
+    @DisplayName("updateProfile - OTHER → KO 변경 시 customFirstLanguage null 처리")
+    void updateProfile_otherToKo_clearsCustomLanguage() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage("태국어");
+
+        profile.updateProfile(
+                "민준", AgeGroup.AGE_7_8,
+                Language.KO, "이 값은 무시돼야 함", LanguageProficiency.BEE,
+                Language.VI, null, LanguageProficiency.LARVA,
+                LanguageProficiency.BEE, LanguageProficiency.PUPA,
+                LanguageProficiency.LARVA, LanguageProficiency.EGG,
+                FamilyStructure.TWO_PARENTS, null,
+                StoryPreference.FUN_ADVENTURE, null,
+                "KR", "VN"
+        );
+
+        assertThat(profile.getFirstLanguage()).isEqualTo(Language.KO);
+        assertThat(profile.getCustomFirstLanguage()).isNull();
+        assertThat(profile.getChildAge()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("updateProfile - CUSTOM → TWO_PARENTS 변경 시 customFamilyStructure null 처리")
+    void updateProfile_customToTwoParents_clearsFamilyStructure() {
+        UserProfile profile = buildProfile(AgeGroup.AGE_5_6);
+        profile.setFamilyStructure(FamilyStructure.CUSTOM);
+        profile.setCustomFamilyStructure("조부모님과 살아요");
+
+        profile.updateProfile(
+                "민준", AgeGroup.AGE_5_6,
+                Language.KO, null, LanguageProficiency.BEE,
+                Language.VI, null, LanguageProficiency.LARVA,
+                LanguageProficiency.BEE, LanguageProficiency.PUPA,
+                LanguageProficiency.LARVA, LanguageProficiency.EGG,
+                FamilyStructure.TWO_PARENTS, "이 값 무시",
+                StoryPreference.FUN_ADVENTURE, null, null, null
+        );
+
+        assertThat(profile.getFamilyStructure()).isEqualTo(FamilyStructure.TWO_PARENTS);
+        assertThat(profile.getCustomFamilyStructure()).isNull();
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private UserProfile buildProfile(AgeGroup ageGroup) {
+        return UserProfile.builder()
+                .user(testUser)
+                .childName("민준")
+                .ageGroup(ageGroup)
+                .childAge(ageGroup.getRepresentativeAge())
+                .firstLanguage(Language.KO)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+    }
+}

--- a/src/test/java/com/moretale/domain/profile/service/UserProfileServiceTest.java
+++ b/src/test/java/com/moretale/domain/profile/service/UserProfileServiceTest.java
@@ -1,0 +1,444 @@
+package com.moretale.domain.profile.service;
+
+import com.moretale.domain.profile.dto.*;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProfileService 단위 테스트")
+class UserProfileServiceTest {
+
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock UserRepository userRepository;
+
+    @InjectMocks UserProfileService userProfileService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L)
+                .email("test@example.com")
+                .nickname("홍길동")
+                .role(User.Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - 정상 (일반 언어)")
+    void createOnboardingProfile_success_normalLanguage() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.existsByUser_UserIdAndChildName(1L, "민준")).willReturn(false);
+        given(userProfileRepository.save(any(UserProfile.class)))
+                .willAnswer(inv -> {
+                    UserProfile p = inv.getArgument(0);
+                    // 저장 후 id 세팅 흉내
+                    return UserProfile.builder()
+                            .profileId(10L)
+                            .user(testUser)
+                            .childName(p.getChildName())
+                            .ageGroup(p.getAgeGroup())
+                            .childAge(p.getAgeGroup().getRepresentativeAge())
+                            .firstLanguage(p.getFirstLanguage())
+                            .customFirstLanguage(p.getCustomFirstLanguage())
+                            .firstLanguageProficiency(p.getFirstLanguageProficiency())
+                            .secondLanguage(p.getSecondLanguage())
+                            .customSecondLanguage(p.getCustomSecondLanguage())
+                            .secondLanguageProficiency(p.getSecondLanguageProficiency())
+                            .firstLanguageListening(p.getFirstLanguageListening())
+                            .firstLanguageSpeaking(p.getFirstLanguageSpeaking())
+                            .secondLanguageListening(p.getSecondLanguageListening())
+                            .secondLanguageSpeaking(p.getSecondLanguageSpeaking())
+                            .familyStructure(p.getFamilyStructure())
+                            .storyPreference(p.getStoryPreference())
+                            .build();
+                });
+
+        OnboardingProfileRequest request = validOnboardingRequest();
+
+        // when
+        OnboardingProfileResponse response =
+                userProfileService.createOnboardingProfile(1L, request);
+
+        // then
+        assertThat(response.getProfileId()).isEqualTo(10L);
+        assertThat(response.getChildName()).isEqualTo("민준");
+        assertThat(response.getFirstLanguage()).isEqualTo(Language.KO);
+        assertThat(response.getCustomFirstLanguage()).isNull();
+        verify(userProfileRepository).save(any(UserProfile.class));
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - OTHER 언어 + customFirstLanguage 저장")
+    void createOnboardingProfile_success_otherLanguage() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.existsByUser_UserIdAndChildName(1L, "민준")).willReturn(false);
+        given(userProfileRepository.save(any(UserProfile.class)))
+                .willAnswer(inv -> {
+                    UserProfile p = inv.getArgument(0);
+                    // OTHER인 경우 customFirstLanguage 저장 확인
+                    assertThat(p.getCustomFirstLanguage()).isEqualTo("태국어");
+                    return buildSavedProfile(p, 10L);
+                });
+
+        OnboardingProfileRequest request = validOnboardingRequest();
+        request.setFirstLanguage(Language.OTHER);
+        request.setCustomFirstLanguage("태국어");
+
+        // when
+        userProfileService.createOnboardingProfile(1L, request);
+
+        // then
+        verify(userProfileRepository).save(any(UserProfile.class));
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - OTHER가 아닌 언어 선택 시 customFirstLanguage null 처리")
+    void createOnboardingProfile_nonOtherLanguage_customLanguageSetNull() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.existsByUser_UserIdAndChildName(1L, "민준")).willReturn(false);
+        given(userProfileRepository.save(any(UserProfile.class)))
+                .willAnswer(inv -> {
+                    UserProfile p = inv.getArgument(0);
+                    // KO 선택 시 custom은 null이어야 함
+                    assertThat(p.getCustomFirstLanguage()).isNull();
+                    return buildSavedProfile(p, 10L);
+                });
+
+        OnboardingProfileRequest request = validOnboardingRequest();
+        request.setFirstLanguage(Language.KO);
+        request.setCustomFirstLanguage("이 값은 무시돼야 함");
+
+        // when
+        userProfileService.createOnboardingProfile(1L, request);
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - 사용자 없음 → USER_NOT_FOUND")
+    void createOnboardingProfile_userNotFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                userProfileService.createOnboardingProfile(99L, validOnboardingRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("온보딩 프로필 생성 - 동일 이름 자녀 이미 존재 → PROFILE_ALREADY_EXISTS")
+    void createOnboardingProfile_alreadyExists() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.existsByUser_UserIdAndChildName(1L, "민준")).willReturn(true);
+
+        assertThatThrownBy(() ->
+                userProfileService.createOnboardingProfile(1L, validOnboardingRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PROFILE_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 - 정상")
+    void updateProfile_success() {
+        UserProfile existingProfile = buildExistingProfile(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findById(10L)).willReturn(Optional.of(existingProfile));
+
+        UserProfileRequest request = validProfileRequest();
+        request.setChildName("지우");
+        request.setAgeGroup(AgeGroup.AGE_7_8);
+
+        UserProfileResponse response = userProfileService.updateProfile(1L, 10L, request);
+
+        assertThat(response.getChildName()).isEqualTo("지우");
+        assertThat(response.getAgeGroup()).isEqualTo(AgeGroup.AGE_7_8);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 - 본인 소유 아님 → FORBIDDEN")
+    void updateProfile_forbiddenForOtherUser() {
+        User anotherUser = User.builder().userId(2L).email("other@example.com").build();
+        UserProfile profileOwnedByAnother = buildProfileForUser(anotherUser, 10L);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findById(10L)).willReturn(Optional.of(profileOwnedByAnother));
+
+        assertThatThrownBy(() ->
+                userProfileService.updateProfile(1L, 10L, validProfileRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 - 프로필 없음 → PROFILE_NOT_FOUND")
+    void updateProfile_profileNotFound() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                userProfileService.updateProfile(1L, 999L, validProfileRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PROFILE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("언어 수정 - KO → EN 변경 + Legacy 동기화")
+    void updateLanguage_success_enumChange() {
+        UserProfile profile = buildExistingProfile(1L);
+        given(userProfileRepository.findById(10L)).willReturn(Optional.of(profile));
+
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.EN)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.JA)
+                .customSecondLanguage(null)
+                .build();
+
+        UserProfileResponse response = userProfileService.updateLanguage(10L, request);
+
+        assertThat(response.getFirstLanguage()).isEqualTo(Language.EN);
+        assertThat(response.getSecondLanguage()).isEqualTo(Language.JA);
+        assertThat(response.getCustomFirstLanguage()).isNull();
+    }
+
+    @Test
+    @DisplayName("언어 수정 - OTHER → customSecondLanguage 저장")
+    void updateLanguage_success_otherWithCustom() {
+        UserProfile profile = buildExistingProfile(1L);
+        given(userProfileRepository.findById(10L)).willReturn(Optional.of(profile));
+
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("태국어")
+                .build();
+
+        UserProfileResponse response = userProfileService.updateLanguage(10L, request);
+
+        assertThat(response.getSecondLanguage()).isEqualTo(Language.OTHER);
+        assertThat(response.getCustomSecondLanguage()).isEqualTo("태국어");
+    }
+
+    @Test
+    @DisplayName("언어 수정 - OTHER + custom 누락 → IllegalArgumentException")
+    void updateLanguage_otherWithoutCustom_throws() {
+        LanguageUpdateRequest request = LanguageUpdateRequest.builder()
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .build();
+
+        assertThatThrownBy(() -> userProfileService.updateLanguage(10L, request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("전체 프로필 목록 조회")
+    void getAllProfiles_returnsList() {
+        UserProfile p1 = buildExistingProfile(1L);
+        UserProfile p2 = buildExistingProfile(2L);
+        given(userProfileRepository.findAllByUser_UserId(1L)).willReturn(List.of(p1, p2));
+
+        List<UserProfileResponse> profiles = userProfileService.getAllProfiles(1L);
+
+        assertThat(profiles).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("hasProfile - 프로필 존재 시 true")
+    void hasProfile_returnsTrue() {
+        given(userProfileRepository.existsByUser_UserId(1L)).willReturn(true);
+        assertThat(userProfileService.hasProfile(1L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasProfile - 프로필 없음 시 false")
+    void hasProfile_returnsFalse() {
+        given(userProfileRepository.existsByUser_UserId(1L)).willReturn(false);
+        assertThat(userProfileService.hasProfile(1L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("syncLegacyLanguages - KO 선택 시 primaryLanguage = KO")
+    void syncLegacyLanguages_normalEnum() {
+        UserProfile profile = buildExistingProfile(1L);
+        profile.setFirstLanguage(Language.KO);
+        profile.setCustomFirstLanguage(null);
+        profile.syncLegacyLanguages();
+
+        assertThat(profile.getPrimaryLanguage()).isEqualTo("KO");
+    }
+
+    @Test
+    @DisplayName("syncLegacyLanguages - OTHER + custom 시 primaryLanguage = custom 값")
+    void syncLegacyLanguages_otherWithCustom() {
+        UserProfile profile = buildExistingProfile(1L);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage("태국어");
+        profile.syncLegacyLanguages();
+
+        assertThat(profile.getPrimaryLanguage()).isEqualTo("태국어");
+    }
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - KO → 한국어")
+    void getFirstLanguageDisplay_ko() {
+        UserProfile profile = buildExistingProfile(1L);
+        profile.setFirstLanguage(Language.KO);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("한국어");
+    }
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - OTHER + custom → custom 값 반환")
+    void getFirstLanguageDisplay_otherWithCustom() {
+        UserProfile profile = buildExistingProfile(1L);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage("태국어");
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("태국어");
+    }
+
+    @Test
+    @DisplayName("getFirstLanguageDisplay - OTHER + null → 기타")
+    void getFirstLanguageDisplay_otherWithNull() {
+        UserProfile profile = buildExistingProfile(1L);
+        profile.setFirstLanguage(Language.OTHER);
+        profile.setCustomFirstLanguage(null);
+        assertThat(profile.getFirstLanguageDisplay()).isEqualTo("기타");
+    }
+
+    private OnboardingProfileRequest validOnboardingRequest() {
+        return OnboardingProfileRequest.builder()
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .customFamilyStructure(null)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .customStoryPreference(null)
+                .build();
+    }
+
+    private UserProfileRequest validProfileRequest() {
+        return UserProfileRequest.builder()
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .firstLanguage(Language.KO)
+                .secondLanguage(Language.VI)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+    }
+
+    private UserProfile buildExistingProfile(Long profileId) {
+        UserProfile p = UserProfile.builder()
+                .profileId(profileId)
+                .user(testUser)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+        p.syncLegacyLanguages();
+        return p;
+    }
+
+    private UserProfile buildProfileForUser(User user, Long profileId) {
+        return UserProfile.builder()
+                .profileId(profileId)
+                .user(user)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.KO)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+    }
+
+    private UserProfile buildSavedProfile(UserProfile p, Long profileId) {
+        return UserProfile.builder()
+                .profileId(profileId)
+                .user(p.getUser())
+                .childName(p.getChildName())
+                .ageGroup(p.getAgeGroup())
+                .childAge(p.getAgeGroup().getRepresentativeAge())
+                .firstLanguage(p.getFirstLanguage())
+                .customFirstLanguage(p.getCustomFirstLanguage())
+                .firstLanguageProficiency(p.getFirstLanguageProficiency())
+                .secondLanguage(p.getSecondLanguage())
+                .customSecondLanguage(p.getCustomSecondLanguage())
+                .secondLanguageProficiency(p.getSecondLanguageProficiency())
+                .firstLanguageListening(p.getFirstLanguageListening())
+                .firstLanguageSpeaking(p.getFirstLanguageSpeaking())
+                .secondLanguageListening(p.getSecondLanguageListening())
+                .secondLanguageSpeaking(p.getSecondLanguageSpeaking())
+                .familyStructure(p.getFamilyStructure())
+                .customFamilyStructure(p.getCustomFamilyStructure())
+                .storyPreference(p.getStoryPreference())
+                .customStoryPreference(p.getCustomStoryPreference())
+                .childNationality(p.getChildNationality())
+                .parentCountry(p.getParentCountry())
+                .build();
+    }
+}

--- a/src/test/java/com/moretale/domain/quiz/controller/QuizControllerIntegrationTest.java
+++ b/src/test/java/com/moretale/domain/quiz/controller/QuizControllerIntegrationTest.java
@@ -1,0 +1,247 @@
+package com.moretale.domain.quiz.controller;
+
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.honeyjar.repository.HoneyJarRepository;
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.quiz.dto.QuizSubmitRequest;
+import com.moretale.domain.quiz.dto.StoryCompleteRequest;
+import com.moretale.domain.quiz.entity.*;
+import com.moretale.domain.quiz.repository.QuizRepository;
+import com.moretale.domain.quiz.repository.StoryReadStatusRepository;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import com.moretale.support.IntegrationTestSupport;
+import com.moretale.support.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Quiz Controller 통합 테스트")
+class QuizControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired UserRepository userRepository;
+    @Autowired UserProfileRepository userProfileRepository;
+    @Autowired StoryRepository storyRepository;
+    @Autowired QuizRepository quizRepository;
+    @Autowired StoryReadStatusRepository storyReadStatusRepository;
+    @Autowired HoneyJarRepository honeyJarRepository;
+
+    private User testUser;
+    private UserProfile testProfile;
+    private Story testStory;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(TestFixture.createUser("quiz-test@example.com"));
+        testProfile = userProfileRepository.save(TestFixture.createProfile(testUser));
+        testStory = storyRepository.save(
+                TestFixture.createStory(testUser, testProfile, "흥부와 놀부"));
+        setAuthentication(testUser);
+    }
+
+    // ────────────────── POST /api/quiz/submit ──────────────────
+
+    @Test
+    @DisplayName("퀴즈 제출 - 100점 → 꿀단지 1개 지급")
+    void submitQuiz_perfectScore_earnHoneyJar() throws Exception {
+        Quiz quiz = saveQuizWithQuestions(testStory, 2);
+
+        List<QuizSubmitRequest.AnswerDto> answers = quiz.getQuestions().stream()
+                .map(q -> new QuizSubmitRequest.AnswerDto(
+                        q.getQuestionId(), q.getCorrectAnswer()))
+                .toList();
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(quiz.getQuizId())
+                .answers(answers)
+                .build();
+
+        mockMvc.perform(post("/api/quiz/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.score").value(100))
+                .andExpect(jsonPath("$.data.isPerfect").value(true))
+                .andExpect(jsonPath("$.data.honeyJarReward.earnedHoneyJars").value(1))
+                .andExpect(jsonPath("$.data.resultMessage").value("🎉 완벽해요! 모든 문제를 맞혔어요!"));
+
+        HoneyJar honeyJar = honeyJarRepository.findByUser(testUser).orElseThrow();
+        assertThat(honeyJar.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 전부 오답 → 0점, 꿀단지 미지급")
+    void submitQuiz_zeroScore_noHoneyJar() throws Exception {
+        Quiz quiz = saveQuizWithQuestions(testStory, 2);
+
+        List<QuizSubmitRequest.AnswerDto> wrongAnswers = quiz.getQuestions().stream()
+                .map(q -> new QuizSubmitRequest.AnswerDto(q.getQuestionId(), "9"))
+                .toList();
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(quiz.getQuizId())
+                .answers(wrongAnswers)
+                .build();
+
+        mockMvc.perform(post("/api/quiz/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.score").value(0))
+                .andExpect(jsonPath("$.data.isPerfect").value(false))
+                .andExpect(jsonPath("$.data.honeyJarReward.earnedHoneyJars").value(0));
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 문항별 정오 결과 포함 응답")
+    void submitQuiz_returnsAnswerResults() throws Exception {
+        Quiz quiz = saveQuizWithQuestions(testStory, 2);
+
+        QuizSubmitRequest.AnswerDto correct = new QuizSubmitRequest.AnswerDto(
+                quiz.getQuestions().get(0).getQuestionId(),
+                quiz.getQuestions().get(0).getCorrectAnswer());
+        QuizSubmitRequest.AnswerDto wrong = new QuizSubmitRequest.AnswerDto(
+                quiz.getQuestions().get(1).getQuestionId(), "9");
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(quiz.getQuizId())
+                .answers(List.of(correct, wrong))
+                .build();
+
+        mockMvc.perform(post("/api/quiz/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.answerResults", hasSize(2)))
+                .andExpect(jsonPath("$.data.answerResults[0].isCorrect").value(true))
+                .andExpect(jsonPath("$.data.answerResults[1].isCorrect").value(false));
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 퀴즈 없음 → 404")
+    void submitQuiz_quizNotFound_404() throws Exception {
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(9999L)
+                .answers(List.of(new QuizSubmitRequest.AnswerDto(1L, "1")))
+                .build();
+
+        mockMvc.perform(post("/api/quiz/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("Q001"));
+    }
+
+    // ────────────────── POST /api/quiz/story-complete ──────────────────
+
+    @Test
+    @DisplayName("동화 완독 - 최초 완독 → 꿀단지 +1")
+    void completeStory_firstTime_earnHoneyJar() throws Exception {
+        StoryCompleteRequest request = new StoryCompleteRequest(testStory.getStoryId());
+
+        mockMvc.perform(post("/api/quiz/story-complete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.earnedHoneyJars").value(1))
+                .andExpect(jsonPath("$.data.currentHoneyJarCount").value(1));
+
+        HoneyJar honeyJar = honeyJarRepository.findByUser(testUser).orElseThrow();
+        assertThat(honeyJar.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("동화 완독 - 이미 완독 보상 받음 → 중복 지급 없음")
+    void completeStory_alreadyRewarded_noDouble() throws Exception {
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser).story(testStory)
+                .isCompleted(true).readHoneyJarRewarded(true).build();
+        storyReadStatusRepository.save(readStatus);
+
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(2).totalEarned(2).totalUsed(0).build();
+        honeyJarRepository.save(honeyJar);
+
+        StoryCompleteRequest request = new StoryCompleteRequest(testStory.getStoryId());
+
+        mockMvc.perform(post("/api/quiz/story-complete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.earnedHoneyJars").value(0))
+                .andExpect(jsonPath("$.data.currentHoneyJarCount").value(2));
+    }
+
+    @Test
+    @DisplayName("동화 완독 - 9개 보유 후 완독 → 10개 달성 자동 차감")
+    void completeStory_reaches10_autoDeduct() throws Exception {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(9).totalEarned(9).totalUsed(0).build();
+        honeyJarRepository.save(honeyJar);
+
+        StoryCompleteRequest request = new StoryCompleteRequest(testStory.getStoryId());
+
+        mockMvc.perform(post("/api/quiz/story-complete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.autoUsedForFreeGeneration").value(true));
+
+        HoneyJar updated = honeyJarRepository.findByUser(testUser).orElseThrow();
+        assertThat(updated.getCount()).isEqualTo(0);
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private Quiz saveQuizWithQuestions(Story story, int count) {
+        Quiz quiz = Quiz.builder()
+                .story(story).language("ko")
+                .difficulty(QuizDifficulty.NORMAL)
+                .totalQuestions(count)
+                .build();
+
+        for (int i = 1; i <= count; i++) {
+            QuizQuestion q = QuizQuestion.builder()
+                    .questionType(QuestionType.MULTIPLE_CHOICE)
+                    .evaluationType(EvaluationType.STORY)
+                    .questionOrder(i)
+                    .questionText("문제 " + i)
+                    .correctAnswer(String.valueOf(i))
+                    .explanation("해설 " + i)
+                    .build();
+            quiz.addQuestion(q);
+        }
+
+        return quizRepository.save(quiz);
+    }
+
+    private void setAuthentication(User user) {
+        UserPrincipal principal = UserPrincipal.create(user);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities()));
+    }
+}

--- a/src/test/java/com/moretale/domain/quiz/entity/QuizResultTest.java
+++ b/src/test/java/com/moretale/domain/quiz/entity/QuizResultTest.java
@@ -1,0 +1,35 @@
+package com.moretale.domain.quiz.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("QuizResult 점수 계산 테스트")
+class QuizResultTest {
+
+    @ParameterizedTest(name = "correct={0}, total={1} → score={2}")
+    @CsvSource({
+            "0,  0,   0",   // 0문제 → 0점
+            "0,  5,   0",   // 전부 오답
+            "5,  5, 100",   // 전부 정답
+            "3,  5,  60",   // 60점
+            "6,  7,  86",   // 반올림: 6/7 * 100 = 85.7 → 86
+            "1,  7,  14",   // 반올림: 1/7 * 100 = 14.28 → 14
+            "1,  3,  33",   // 반올림: 1/3 * 100 = 33.33 → 33
+    })
+    @DisplayName("calculateScore - 정답 수 / 총 문제 수 × 100, 반올림")
+    void calculateScore(int correct, int total, int expected) {
+        int result = QuizResult.calculateScore(correct, total);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "correct={0}, total={1}")
+    @CsvSource({"7, 7", "10, 10"})
+    @DisplayName("calculateScore - 100점이면 isPerfect 로직과 일치")
+    void calculateScore_perfectShouldBeHundred(int correct, int total) {
+        int score = QuizResult.calculateScore(correct, total);
+        assertThat(score).isEqualTo(100);
+    }
+}

--- a/src/test/java/com/moretale/domain/quiz/service/QuizServiceTest.java
+++ b/src/test/java/com/moretale/domain/quiz/service/QuizServiceTest.java
@@ -1,0 +1,321 @@
+package com.moretale.domain.quiz.service;
+
+import com.moretale.domain.honeyjar.service.HoneyJarService;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.quiz.dto.QuizResultResponse;
+import com.moretale.domain.quiz.dto.QuizSubmitRequest;
+import com.moretale.domain.quiz.entity.*;
+import com.moretale.domain.quiz.repository.*;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuizService 단위 테스트")
+class QuizServiceTest {
+
+    @Mock QuizRepository quizRepository;
+    @Mock QuizResultRepository quizResultRepository;
+    @Mock StoryReadStatusRepository storyReadStatusRepository;
+    @Mock StoryRepository storyRepository;
+    @Mock UserRepository userRepository;
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock AIQuizService aiQuizService;
+    @Mock HoneyJarService honeyJarService;
+
+    @InjectMocks QuizService quizService;
+
+    private User testUser;
+    private Story testStory;
+    private UserProfile testProfile;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder().userId(1L).email("test@example.com").build();
+
+        testProfile = UserProfile.builder()
+                .profileId(10L)
+                .user(testUser)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.KO)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+
+        testStory = Story.builder()
+                .storyId(5L)
+                .title("흥부와 놀부")
+                .user(testUser)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("퀴즈 조회 - 기존 퀴즈 있으면 바로 반환")
+    void getOrGenerateQuiz_existingQuiz_returnsCached() {
+        Quiz existingQuiz = Quiz.builder()
+                .quizId(1L)
+                .story(testStory)
+                .language("ko")
+                .difficulty(QuizDifficulty.NORMAL)
+                .totalQuestions(5)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findByIdWithSlides(5L)).willReturn(Optional.of(testStory));
+        given(quizRepository.findByStoryWithQuestions(testStory))
+                .willReturn(Optional.of(existingQuiz));
+
+        var response = quizService.getOrGenerateQuiz(1L, 5L);
+
+        assertThat(response.getQuizId()).isEqualTo(1L);
+        // aiQuizService는 호출되지 않아야 함
+    }
+
+    @Test
+    @DisplayName("퀴즈 조회 - 비공개 타인 동화 접근 → STORY_ACCESS_DENIED")
+    void getOrGenerateQuiz_privateStory_accessDenied() {
+        User otherUser = User.builder().userId(2L).build();
+        Story privateStory = Story.builder()
+                .storyId(99L)
+                .user(otherUser)
+                .isPublic(false)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findByIdWithSlides(99L)).willReturn(Optional.of(privateStory));
+
+        assertThatThrownBy(() -> quizService.getOrGenerateQuiz(1L, 99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.STORY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 100점 달성 + 꿀단지 첫 보상")
+    void submitQuiz_perfectScore_earnHoneyJar() {
+        QuizQuestion q1 = buildQuestion(1L, 1, "1");
+        QuizQuestion q2 = buildQuestion(2L, 2, "2");
+
+        Quiz quiz = Quiz.builder()
+                .quizId(1L)
+                .story(testStory)
+                .language("ko")
+                .difficulty(QuizDifficulty.NORMAL)
+                .totalQuestions(2)
+                .build();
+        quiz.addQuestion(q1);
+        quiz.addQuestion(q2);
+
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser)
+                .story(testStory)
+                .quizHoneyJarRewarded(false)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(quizRepository.findByIdWithQuestions(1L)).willReturn(Optional.of(quiz));
+        given(storyReadStatusRepository.findByUserAndStory(testUser, testStory))
+                .willReturn(Optional.of(readStatus));
+        given(quizResultRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarService.addHoneyJarAndCheckAutoUse(any(), any(), any()))
+                .willReturn(false);
+        given(honeyJarService.getOrCreateHoneyJar(testUser))
+                .willReturn(com.moretale.domain.honeyjar.entity.HoneyJar.builder()
+                        .user(testUser).count(1).totalEarned(1).totalUsed(0).build());
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(1L)
+                .answers(List.of(
+                        new QuizSubmitRequest.AnswerDto(1L, "1"),
+                        new QuizSubmitRequest.AnswerDto(2L, "2")
+                ))
+                .build();
+
+        QuizResultResponse response = quizService.submitQuiz(1L, request);
+
+        assertThat(response.getScore()).isEqualTo(100);
+        assertThat(response.getIsPerfect()).isTrue();
+        assertThat(response.getHoneyJarReward().getEarnedHoneyJars()).isEqualTo(1);
+        verify(honeyJarService).addHoneyJarAndCheckAutoUse(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 100점 미달 → 꿀단지 미지급")
+    void submitQuiz_notPerfect_noHoneyJar() {
+        QuizQuestion q1 = buildQuestion(1L, 1, "1");
+        QuizQuestion q2 = buildQuestion(2L, 2, "2");
+
+        Quiz quiz = Quiz.builder()
+                .quizId(1L)
+                .story(testStory)
+                .language("ko")
+                .difficulty(QuizDifficulty.NORMAL)
+                .totalQuestions(2)
+                .build();
+        quiz.addQuestion(q1);
+        quiz.addQuestion(q2);
+
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser)
+                .story(testStory)
+                .quizHoneyJarRewarded(false)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(quizRepository.findByIdWithQuestions(1L)).willReturn(Optional.of(quiz));
+        given(storyReadStatusRepository.findByUserAndStory(testUser, testStory))
+                .willReturn(Optional.of(readStatus));
+        given(quizResultRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarService.getOrCreateHoneyJar(testUser))
+                .willReturn(com.moretale.domain.honeyjar.entity.HoneyJar.builder()
+                        .user(testUser).count(0).totalEarned(0).totalUsed(0).build());
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(1L)
+                .answers(List.of(
+                        new QuizSubmitRequest.AnswerDto(1L, "1"),  // 정답
+                        new QuizSubmitRequest.AnswerDto(2L, "3")   // 오답
+                ))
+                .build();
+
+        QuizResultResponse response = quizService.submitQuiz(1L, request);
+
+        assertThat(response.getScore()).isEqualTo(50);
+        assertThat(response.getIsPerfect()).isFalse();
+        assertThat(response.getHoneyJarReward().getEarnedHoneyJars()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("퀴즈 제출 - 이미 보상 받은 경우 중복 지급 안 함")
+    void submitQuiz_alreadyRewarded_noDoubleReward() {
+        QuizQuestion q1 = buildQuestion(1L, 1, "1");
+
+        Quiz quiz = Quiz.builder()
+                .quizId(1L)
+                .story(testStory)
+                .language("ko")
+                .difficulty(QuizDifficulty.NORMAL)
+                .totalQuestions(1)
+                .build();
+        quiz.addQuestion(q1);
+
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser)
+                .story(testStory)
+                .quizHoneyJarRewarded(true) // 이미 받음
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(quizRepository.findByIdWithQuestions(1L)).willReturn(Optional.of(quiz));
+        given(storyReadStatusRepository.findByUserAndStory(testUser, testStory))
+                .willReturn(Optional.of(readStatus));
+        given(quizResultRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarService.getOrCreateHoneyJar(testUser))
+                .willReturn(com.moretale.domain.honeyjar.entity.HoneyJar.builder()
+                        .user(testUser).count(3).totalEarned(3).totalUsed(0).build());
+
+        QuizSubmitRequest request = QuizSubmitRequest.builder()
+                .quizId(1L)
+                .answers(List.of(new QuizSubmitRequest.AnswerDto(1L, "1")))
+                .build();
+
+        QuizResultResponse response = quizService.submitQuiz(1L, request);
+
+        assertThat(response.getHoneyJarReward().getEarnedHoneyJars()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("동화 완독 - 최초 완독 시 꿀단지 +1 지급")
+    void completeStory_firstTime_earnHoneyJar() {
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser)
+                .story(testStory)
+                .readHoneyJarRewarded(false)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findByIdWithSlides(5L)).willReturn(Optional.of(testStory));
+        given(storyReadStatusRepository.findByUserAndStory(testUser, testStory))
+                .willReturn(Optional.of(readStatus));
+        given(storyReadStatusRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(honeyJarService.addHoneyJarAndCheckAutoUse(any(), any(), any())).willReturn(false);
+        given(honeyJarService.getOrCreateHoneyJar(testUser))
+                .willReturn(com.moretale.domain.honeyjar.entity.HoneyJar.builder()
+                        .user(testUser).count(1).totalEarned(1).totalUsed(0).build());
+
+        QuizResultResponse.HoneyJarRewardInfo reward =
+                quizService.completeStory(1L, 5L);
+
+        assertThat(reward.getEarnedHoneyJars()).isEqualTo(1);
+        verify(honeyJarService).addHoneyJarAndCheckAutoUse(any(), any(), eq(5L));
+    }
+
+    @Test
+    @DisplayName("동화 완독 - 이미 완독 보상 받음 → 중복 지급 없음")
+    void completeStory_alreadyRewarded_noDoubleReward() {
+        StoryReadStatus readStatus = StoryReadStatus.builder()
+                .user(testUser)
+                .story(testStory)
+                .readHoneyJarRewarded(true)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findByIdWithSlides(5L)).willReturn(Optional.of(testStory));
+        given(storyReadStatusRepository.findByUserAndStory(testUser, testStory))
+                .willReturn(Optional.of(readStatus));
+        given(honeyJarService.getOrCreateHoneyJar(testUser))
+                .willReturn(com.moretale.domain.honeyjar.entity.HoneyJar.builder()
+                        .user(testUser).count(2).totalEarned(2).totalUsed(0).build());
+
+        QuizResultResponse.HoneyJarRewardInfo reward =
+                quizService.completeStory(1L, 5L);
+
+        assertThat(reward.getEarnedHoneyJars()).isEqualTo(0);
+    }
+
+    private QuizQuestion buildQuestion(Long id, int order, String correctAnswer) {
+        return QuizQuestion.builder()
+                .questionId(id)
+                .questionType(QuestionType.MULTIPLE_CHOICE)
+                .evaluationType(EvaluationType.STORY)
+                .questionOrder(order)
+                .questionText("문제 " + order)
+                .correctAnswer(correctAnswer)
+                .explanation("해설 " + order)
+                .build();
+    }
+}

--- a/src/test/java/com/moretale/domain/story/controller/LibraryControllerIntegrationTest.java
+++ b/src/test/java/com/moretale/domain/story/controller/LibraryControllerIntegrationTest.java
@@ -1,0 +1,163 @@
+package com.moretale.domain.story.controller;
+
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import com.moretale.support.IntegrationTestSupport;
+import com.moretale.support.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Library Controller 통합 테스트")
+class LibraryControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired UserRepository userRepository;
+    @Autowired UserProfileRepository userProfileRepository;
+    @Autowired StoryRepository storyRepository;
+
+    private User testUser;
+    private UserProfile testProfile;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(TestFixture.createUser("library-test@example.com"));
+        testProfile = userProfileRepository.save(TestFixture.createProfile(testUser));
+        setAuthentication(testUser);
+    }
+
+    // ────────────────── GET /api/library ──────────────────
+
+    @Test
+    @DisplayName("도서관 조회 - 기본값 (최신순) 정상 응답")
+    void getLibrary_defaultSort_success() throws Exception {
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "동화1"));
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "동화2"));
+
+        mockMvc.perform(get("/api/library"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content", hasSize(2)))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 동화 없음 → 빈 페이지")
+    void getLibrary_empty_returnsEmptyPage() throws Exception {
+        mockMvc.perform(get("/api/library"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content").isEmpty())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 가나다순 정렬 (title ASC)")
+    void getLibrary_titleSort_success() throws Exception {
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "흥부와 놀부"));
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "가나다 순 동화"));
+
+        mockMvc.perform(get("/api/library?sort=title,asc"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].title").value("가나다 순 동화"))
+                .andExpect(jsonPath("$.data.content[1].title").value("흥부와 놀부"));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 썸네일은 첫 번째 슬라이드 imageUrl")
+    void getLibrary_thumbnailFromFirstSlide() throws Exception {
+        Story story = TestFixture.createStory(testUser, testProfile, "썸네일 테스트");
+        Slide cover = TestFixture.createCoverSlide("https://example.com/cover.png");
+        story.addSlide(cover);
+        storyRepository.save(story);
+
+        mockMvc.perform(get("/api/library"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].thumbnail")
+                        .value("https://example.com/cover.png"));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 타인의 동화는 포함되지 않음")
+    void getLibrary_onlyMyStories() throws Exception {
+        User otherUser = userRepository.save(TestFixture.createUser("other@example.com"));
+        UserProfile otherProfile = userProfileRepository.save(TestFixture.createProfile(otherUser));
+        storyRepository.save(TestFixture.createStory(otherUser, otherProfile, "타인 동화"));
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "내 동화"));
+
+        mockMvc.perform(get("/api/library"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content", hasSize(1)))
+                .andExpect(jsonPath("$.data.content[0].title").value("내 동화"));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 페이징 동작 확인")
+    void getLibrary_pagination_works() throws Exception {
+        for (int i = 1; i <= 5; i++) {
+            storyRepository.save(TestFixture.createStory(testUser, testProfile, "동화" + i));
+        }
+
+        mockMvc.perform(get("/api/library?page=0&size=3"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content", hasSize(3)))
+                .andExpect(jsonPath("$.data.totalElements").value(5))
+                .andExpect(jsonPath("$.data.totalPages").value(2));
+    }
+
+    // ────────────────── DELETE /api/library/{storyId} ──────────────────
+
+    @Test
+    @DisplayName("도서관 동화 삭제 - 정상")
+    void deleteFromLibrary_success() throws Exception {
+        Story story = storyRepository.save(
+                TestFixture.createStory(testUser, testProfile, "삭제할 동화"));
+
+        mockMvc.perform(delete("/api/library/" + story.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("동화가 삭제되었습니다."));
+    }
+
+    @Test
+    @DisplayName("도서관 동화 삭제 - 타인 소유 → 404")
+    void deleteFromLibrary_otherUserStory_404() throws Exception {
+        User otherUser = userRepository.save(TestFixture.createUser("owner@example.com"));
+        UserProfile otherProfile = userProfileRepository.save(TestFixture.createProfile(otherUser));
+        Story otherStory = storyRepository.save(
+                TestFixture.createStory(otherUser, otherProfile, "타인 동화"));
+
+        mockMvc.perform(delete("/api/library/" + otherStory.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("S001"));
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private void setAuthentication(User user) {
+        UserPrincipal principal = UserPrincipal.create(user);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities()));
+    }
+}

--- a/src/test/java/com/moretale/domain/story/controller/StoryControllerIntegrationTest.java
+++ b/src/test/java/com/moretale/domain/story/controller/StoryControllerIntegrationTest.java
@@ -1,0 +1,201 @@
+package com.moretale.domain.story.controller;
+
+import com.moretale.domain.profile.entity.UserProfile;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.security.UserPrincipal;
+import com.moretale.support.IntegrationTestSupport;
+import com.moretale.support.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Story Controller 통합 테스트")
+class StoryControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired UserRepository userRepository;
+    @Autowired UserProfileRepository userProfileRepository;
+    @Autowired StoryRepository storyRepository;
+
+    private User testUser;
+    private UserProfile testProfile;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(TestFixture.createUser("story-test@example.com"));
+        testProfile = userProfileRepository.save(TestFixture.createProfile(testUser));
+        setAuthentication(testUser);
+    }
+
+    @Test
+    @DisplayName("동화 초기값 조회 - 프로필 있음 → 추천 전래동화 반환")
+    void getStoryInitData_success() throws Exception {
+        mockMvc.perform(get("/api/stories/init"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.profileId").value(testProfile.getProfileId()))
+                .andExpect(jsonPath("$.data.childName").value("민준"))
+                .andExpect(jsonPath("$.data.recommendedTaleTitle").isNotEmpty())
+                .andExpect(jsonPath("$.data.firstLanguageDisplay").value("한국어"))
+                .andExpect(jsonPath("$.data.secondLanguageDisplay").value("베트남어"))
+                .andExpect(jsonPath("$.data.storyId").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("동화 초기값 조회 - 추천 동화 이미 생성된 경우 storyId + coverImageUrl 반환")
+    void getStoryInitData_withExistingStory() throws Exception {
+        // 추천 전래동화 제목 생성
+        String recommendedTitle = com.moretale.domain.story.enums.TraditionalTale
+                .findByPreference(testProfile.getStoryPreference()).getTitle();
+
+        Story story = TestFixture.createStory(testUser, testProfile, recommendedTitle);
+        Slide cover = TestFixture.createCoverSlide("https://example.com/cover.png");
+        story.addSlide(cover);
+        story.addSlide(TestFixture.createContentSlide(1, "내용", "content"));
+        storyRepository.save(story);
+
+        mockMvc.perform(get("/api/stories/init"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.storyId").value(story.getStoryId()))
+                .andExpect(jsonPath("$.data.coverImageUrl").value("https://example.com/cover.png"));
+    }
+
+    @Test
+    @DisplayName("동화 초기값 조회 - 프로필 없음 → 404")
+    void getStoryInitData_noProfile_404() throws Exception {
+        // 프로필 없는 새 사용자
+        User userWithoutProfile = userRepository.save(
+                TestFixture.createUser("no-profile@example.com"));
+        setAuthentication(userWithoutProfile);
+
+        mockMvc.perform(get("/api/stories/init"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("P001"));
+    }
+
+    @Test
+    @DisplayName("동화 상세 조회 - 본인 동화 → 슬라이드 포함 응답")
+    void getStoryDetail_ownStory() throws Exception {
+        Story story = TestFixture.createStory(testUser, testProfile, "흥부와 놀부");
+        story.addSlide(TestFixture.createCoverSlide("https://example.com/cover.png"));
+        story.addSlide(TestFixture.createContentSlide(1, "한국어 내용", "베트남어 내용"));
+        storyRepository.save(story);
+
+        mockMvc.perform(get("/api/stories/" + story.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.storyId").value(story.getStoryId()))
+                .andExpect(jsonPath("$.data.title").value("흥부와 놀부"))
+                .andExpect(jsonPath("$.data.slides", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("동화 상세 조회 - 비공개 타인 동화 → 403")
+    void getStoryDetail_privateOtherStory_403() throws Exception {
+        User otherUser = userRepository.save(TestFixture.createUser("other@example.com"));
+        UserProfile otherProfile = userProfileRepository.save(TestFixture.createProfile(otherUser));
+        Story privateStory = TestFixture.createStory(otherUser, otherProfile, "비공개 동화");
+        storyRepository.save(privateStory);
+
+        mockMvc.perform(get("/api/stories/" + privateStory.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("S002"));
+    }
+
+    @Test
+    @DisplayName("동화 상세 조회 - 공개 타인 동화 → 조회 가능")
+    void getStoryDetail_publicOtherStory_accessible() throws Exception {
+        User otherUser = userRepository.save(TestFixture.createUser("public-owner@example.com"));
+        UserProfile otherProfile = userProfileRepository.save(TestFixture.createProfile(otherUser));
+        Story publicStory = Story.builder()
+                .title("공개 동화")
+                .user(otherUser)
+                .profile(otherProfile)
+                .childName("다른아이")
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(true)
+                .build();
+        storyRepository.save(publicStory);
+
+        mockMvc.perform(get("/api/stories/" + publicStory.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("공개 동화"));
+    }
+
+    @Test
+    @DisplayName("내 동화 목록 조회 - 동화 있음")
+    void getMyStories_success() throws Exception {
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "동화1"));
+        storyRepository.save(TestFixture.createStory(testUser, testProfile, "동화2"));
+
+        mockMvc.perform(get("/api/stories/my"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("내 동화 목록 조회 - 동화 없음 → 빈 배열")
+    void getMyStories_empty() throws Exception {
+        mockMvc.perform(get("/api/stories/my"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("동화 공유 설정 변경 - 비공개 → 공개")
+    void updateStoryShareStatus_success() throws Exception {
+        Story story = storyRepository.save(
+                TestFixture.createStory(testUser, testProfile, "공유 테스트 동화"));
+
+        String body = """
+                {"isPublic": true}
+                """;
+
+        mockMvc.perform(patch("/api/stories/" + story.getStoryId() + "/share")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("동화 삭제 - 본인 동화 정상 삭제")
+    void deleteStory_success() throws Exception {
+        Story story = storyRepository.save(
+                TestFixture.createStory(testUser, testProfile, "삭제 대상 동화"));
+
+        mockMvc.perform(delete("/api/stories/" + story.getStoryId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("동화 삭제 완료"));
+    }
+
+    private void setAuthentication(User user) {
+        UserPrincipal principal = UserPrincipal.create(user);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities()));
+    }
+}

--- a/src/test/java/com/moretale/domain/story/service/LibraryServiceTest.java
+++ b/src/test/java/com/moretale/domain/story/service/LibraryServiceTest.java
@@ -1,0 +1,204 @@
+package com.moretale.domain.story.service;
+
+import com.moretale.domain.story.dto.StoryLibraryCardResponse;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LibraryService 단위 테스트")
+class LibraryServiceTest {
+
+    @Mock StoryRepository storyRepository;
+
+    @InjectMocks LibraryService libraryService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder().userId(1L).email("test@example.com").build();
+    }
+
+    // ────────────────── getLibrary ──────────────────
+
+    @Test
+    @DisplayName("도서관 조회 - 정상 결과 반환")
+    void getLibrary_success() {
+        Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Long> idPage = new PageImpl<>(List.of(1L, 2L), pageable, 2);
+
+        Story s1 = buildStory(1L, "동화1");
+        Story s2 = buildStory(2L, "동화2");
+
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(idPage);
+        given(storyRepository.fetchByIdsWithSlides(List.of(1L, 2L)))
+                .willReturn(List.of(s1, s2));
+
+        Page<StoryLibraryCardResponse> result = libraryService.getLibrary(1L, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getStoryId()).isEqualTo(1L);
+        assertThat(result.getContent().get(1).getStoryId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 결과 없으면 빈 페이지 반환")
+    void getLibrary_empty_returnsEmptyPage() {
+        Pageable pageable = PageRequest.of(0, 20);
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        Page<StoryLibraryCardResponse> result = libraryService.getLibrary(1L, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - ID 순서대로 재정렬 보장")
+    void getLibrary_preservesIdOrder() {
+        // DB가 역순으로 반환해도 원래 순서(1,2,3)를 유지해야 함
+        Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Long> idPage = new PageImpl<>(List.of(1L, 2L, 3L), pageable, 3);
+
+        Story s1 = buildStory(1L, "동화1");
+        Story s2 = buildStory(2L, "동화2");
+        Story s3 = buildStory(3L, "동화3");
+
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(idPage);
+        // DB에서 역순으로 반환
+        given(storyRepository.fetchByIdsWithSlides(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(s3, s1, s2));
+
+        Page<StoryLibraryCardResponse> result = libraryService.getLibrary(1L, pageable);
+
+        assertThat(result.getContent().get(0).getStoryId()).isEqualTo(1L);
+        assertThat(result.getContent().get(1).getStoryId()).isEqualTo(2L);
+        assertThat(result.getContent().get(2).getStoryId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - Sort 없으면 createdAt DESC 기본 적용")
+    void getLibrary_unsortedPageable_appliesDefaultSort() {
+        Pageable unsorted = PageRequest.of(0, 20);
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), unsorted, 0));
+
+        libraryService.getLibrary(1L, unsorted);
+
+        verify(storyRepository).findIdsByUserId(eq(1L), argThat(p ->
+                p.getSort().getOrderFor("createdAt") != null &&
+                        p.getSort().getOrderFor("createdAt").getDirection() == Sort.Direction.DESC
+        ));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - 허용되지 않은 정렬 필드는 제거")
+    void getLibrary_illegalSortField_removedFromSort() {
+        Pageable maliciousSort = PageRequest.of(0, 20, Sort.by("userId"));
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), maliciousSort, 0));
+
+        libraryService.getLibrary(1L, maliciousSort);
+
+        // userId 정렬은 제거되고 기본값 createdAt DESC 적용 확인
+        verify(storyRepository).findIdsByUserId(eq(1L), argThat(p ->
+                p.getSort().getOrderFor("userId") == null
+        ));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - title ASC 정렬 허용")
+    void getLibrary_titleSort_allowed() {
+        Pageable titleSort = PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "title"));
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), titleSort, 0));
+
+        libraryService.getLibrary(1L, titleSort);
+
+        verify(storyRepository).findIdsByUserId(eq(1L), argThat(p ->
+                p.getSort().getOrderFor("title") != null
+        ));
+    }
+
+    @Test
+    @DisplayName("도서관 조회 - thumbnail은 첫 번째 슬라이드 imageUrl")
+    void getLibrary_thumbnailFromFirstSlide() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Long> idPage = new PageImpl<>(List.of(1L), pageable, 1);
+
+        Slide slide = Slide.builder()
+                .order(0).imageUrl("https://example.com/thumb.png").build();
+        Story story = buildStory(1L, "동화1");
+        story.addSlide(slide);
+
+        given(storyRepository.findIdsByUserId(eq(1L), any(Pageable.class))).willReturn(idPage);
+        given(storyRepository.fetchByIdsWithSlides(List.of(1L))).willReturn(List.of(story));
+
+        Page<StoryLibraryCardResponse> result = libraryService.getLibrary(1L, pageable);
+
+        assertThat(result.getContent().get(0).getThumbnail())
+                .isEqualTo("https://example.com/thumb.png");
+    }
+
+    // ────────────────── deleteFromLibrary ──────────────────
+
+    @Test
+    @DisplayName("도서관 동화 삭제 - 정상")
+    void deleteFromLibrary_success() {
+        Story story = buildStory(1L, "삭제 동화");
+        given(storyRepository.findByStoryIdAndUserId(1L, 1L)).willReturn(Optional.of(story));
+
+        libraryService.deleteFromLibrary(1L, 1L);
+
+        verify(storyRepository).delete(story);
+    }
+
+    @Test
+    @DisplayName("도서관 동화 삭제 - 존재하지 않음 또는 타인 소유 → STORY_NOT_FOUND")
+    void deleteFromLibrary_notFoundOrNotOwner() {
+        given(storyRepository.findByStoryIdAndUserId(1L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> libraryService.deleteFromLibrary(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.STORY_NOT_FOUND);
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private Story buildStory(Long id, String title) {
+        return Story.builder()
+                .storyId(id)
+                .title(title)
+                .user(testUser)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(false)
+                .build();
+    }
+}

--- a/src/test/java/com/moretale/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/moretale/domain/story/service/StoryServiceTest.java
@@ -1,0 +1,319 @@
+package com.moretale.domain.story.service;
+
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.StoryInitResponse;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.enums.TraditionalTale;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.config.MoreTaleProperties;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoryService 단위 테스트")
+class StoryServiceTest {
+
+    @Mock StoryRepository storyRepository;
+    @Mock UserRepository userRepository;
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock AIStoryService aiStoryService;
+    @Mock StoryTokenService storyTokenService;
+    @Mock MoreTaleProperties properties;
+    @Mock EntityManager em;
+
+    @InjectMocks StoryService storyService;
+
+    private User testUser;
+    private UserProfile testProfile;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L)
+                .email("test@example.com")
+                .nickname("홍길동")
+                .role(User.Role.USER)
+                .build();
+
+        testProfile = UserProfile.builder()
+                .profileId(10L)
+                .user(testUser)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+
+        testProfile.syncLegacyLanguages();
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - 프로필 기반 초기값 반환")
+    void getStoryInitData_success() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findFirstByUserOrderByCreatedAtDesc(testUser))
+                .willReturn(Optional.of(testProfile));
+        given(storyRepository.findLatestStoryIdByProfileAndTitle(
+                eq(1L), eq(10L), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+        given(storyRepository.findLatestStoryIdByUserAndTitle(
+                eq(1L), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+
+        StoryInitResponse response = storyService.getStoryInitData(1L, null);
+
+        assertThat(response.getProfileId()).isEqualTo(10L);
+        assertThat(response.getChildName()).isEqualTo("민준");
+        assertThat(response.getFirstLanguageDisplay()).isEqualTo("한국어");
+        assertThat(response.getSecondLanguageDisplay()).isEqualTo("베트남어");
+        assertThat(response.getStoryId()).isNull();
+        assertThat(response.getCoverImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - FUN_ADVENTURE → 금도끼 은도끼 또는 토끼와 거북이 추천")
+    void getStoryInitData_recommendedTale_funAdventure() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findFirstByUserOrderByCreatedAtDesc(testUser))
+                .willReturn(Optional.of(testProfile));
+        given(storyRepository.findLatestStoryIdByProfileAndTitle(
+                anyLong(), anyLong(), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+        given(storyRepository.findLatestStoryIdByUserAndTitle(
+                anyLong(), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+
+        StoryInitResponse response = storyService.getStoryInitData(1L, null);
+
+        assertThat(response.getRecommendedTaleTitle())
+                .isIn(
+                        TraditionalTale.GOLD_AXE_SILVER_AXE.getTitle(),
+                        TraditionalTale.RABBIT_AND_TURTLE.getTitle()
+                );
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - 이미 생성된 추천 동화 존재 시 storyId + coverImageUrl 반환")
+    void getStoryInitData_withExistingStory() {
+        String recommendedTitle = TraditionalTale.findByPreference(StoryPreference.FUN_ADVENTURE).getTitle();
+
+        Slide coverSlide = Slide.builder()
+                .slideId(1L)
+                .order(0)
+                .imageUrl("https://example.com/cover.png")
+                .textKr("")
+                .textNative("")
+                .build();
+
+        Story existingStory = Story.builder()
+                .storyId(42L)
+                .title(recommendedTitle)
+                .user(testUser)
+                .profile(testProfile)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .build();
+        existingStory.addSlide(coverSlide);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findFirstByUserOrderByCreatedAtDesc(testUser))
+                .willReturn(Optional.of(testProfile));
+        given(storyRepository.findLatestStoryIdByProfileAndTitle(
+                eq(1L), eq(10L), eq(recommendedTitle), any(Pageable.class)))
+                .willReturn(List.of(42L));
+        given(storyRepository.fetchByIdsWithSlides(List.of(42L)))
+                .willReturn(List.of(existingStory));
+
+        StoryInitResponse response = storyService.getStoryInitData(1L, null);
+
+        assertThat(response.getStoryId()).isEqualTo(42L);
+        assertThat(response.getCoverImageUrl()).isEqualTo("https://example.com/cover.png");
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - profileId 직접 지정 시 해당 프로필 사용")
+    void getStoryInitData_withSpecificProfileId() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findByProfileIdAndUser_UserId(10L, 1L))
+                .willReturn(Optional.of(testProfile));
+        given(storyRepository.findLatestStoryIdByProfileAndTitle(
+                anyLong(), anyLong(), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+        given(storyRepository.findLatestStoryIdByUserAndTitle(
+                anyLong(), anyString(), any(Pageable.class)))
+                .willReturn(List.of());
+
+        StoryInitResponse response = storyService.getStoryInitData(1L, 10L);
+
+        assertThat(response.getProfileId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - 사용자 없음 → USER_NOT_FOUND")
+    void getStoryInitData_userNotFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storyService.getStoryInitData(99L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getStoryInitData - 프로필 없음 → PROFILE_NOT_FOUND")
+    void getStoryInitData_profileNotFound() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findFirstByUserOrderByCreatedAtDesc(testUser))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storyService.getStoryInitData(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PROFILE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getStoryDetail - 본인 동화 조회 성공")
+    void getStoryDetail_ownStory_success() {
+        Story story = Story.builder()
+                .storyId(1L)
+                .title("흥부와 놀부")
+                .user(testUser)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(false)
+                .build();
+
+        given(storyRepository.findByIdWithSlides(1L)).willReturn(Optional.of(story));
+
+        var response = storyService.getStoryDetail(1L, 1L);
+
+        assertThat(response.getStoryId()).isEqualTo(1L);
+        assertThat(response.getTitle()).isEqualTo("흥부와 놀부");
+    }
+
+    @Test
+    @DisplayName("getStoryDetail - 공개 동화는 타인도 조회 가능")
+    void getStoryDetail_publicStory_accessibleByOthers() {
+        User owner = User.builder().userId(2L).build();
+        Story story = Story.builder()
+                .storyId(1L)
+                .title("공개 동화")
+                .user(owner)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(true)
+                .build();
+
+        given(storyRepository.findByIdWithSlides(1L)).willReturn(Optional.of(story));
+
+        var response = storyService.getStoryDetail(1L, 1L);
+
+        assertThat(response.getStoryId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getStoryDetail - 비공개 동화 타인 접근 → STORY_ACCESS_DENIED")
+    void getStoryDetail_privateStory_forbiddenForOthers() {
+        User owner = User.builder().userId(2L).build();
+        Story story = Story.builder()
+                .storyId(1L)
+                .title("비공개 동화")
+                .user(owner)
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(false)
+                .build();
+
+        given(storyRepository.findByIdWithSlides(1L)).willReturn(Optional.of(story));
+
+        assertThatThrownBy(() -> storyService.getStoryDetail(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.STORY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("OTHER 언어 프로필 - enqueueAutoStoryGeneration 시 custom 언어 반영")
+    void enqueueAutoStoryGeneration_otherLanguage() {
+        UserProfile otherLangProfile = UserProfile.builder()
+                .profileId(20L)
+                .user(testUser)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.OTHER)
+                .customFirstLanguage("태국어")
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.OTHER)
+                .customSecondLanguage("힌디어")
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+
+        otherLangProfile.syncLegacyLanguages();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findByProfileIdAndUser_UserId(20L, 1L))
+                .willReturn(Optional.of(otherLangProfile));
+
+        MoreTaleProperties.Ai ai = new MoreTaleProperties.Ai();
+        ai.setCallbackBaseUrl("http://localhost:8080");
+        given(properties.getAi()).willReturn(ai);
+
+        given(aiStoryService.enqueueStoryJob(any(), any(), any()))
+                .willAnswer(inv -> {
+                    var req = inv.getArgument(
+                            0,
+                            com.moretale.domain.story.dto.StoryGenerateRequest.class
+                    );
+
+                    assertThat(req.getPrimaryLanguage()).isEqualTo("태국어");
+                    assertThat(req.getSecondaryLanguage()).isEqualTo("힌디어");
+
+                    return com.moretale.domain.story.dto.StoryGenerationJobResponse.builder()
+                            .jobId("test-job")
+                            .status("queued")
+                            .build();
+                });
+
+        storyService.enqueueAutoStoryGeneration(1L, 20L);
+    }
+}

--- a/src/test/java/com/moretale/domain/story/service/impl/StoryTokenServiceImplTest.java
+++ b/src/test/java/com/moretale/domain/story/service/impl/StoryTokenServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.moretale.domain.story.service.impl;
+
+import com.moretale.domain.story.dto.VocabularyItem;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.StoryToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("StoryTokenServiceImpl 단위 테스트")
+class StoryTokenServiceImplTest {
+
+    private StoryTokenServiceImpl service;
+    private Slide testSlide;
+
+    @BeforeEach
+    void setUp() {
+        service = new StoryTokenServiceImpl();
+        testSlide = Slide.builder().slideId(10L).order(1).build();
+    }
+
+    @Test
+    @DisplayName("정상 vocabulary → highlight=true 토큰 생성")
+    void generateTokens_success() {
+        List<VocabularyItem> vocabulary = List.of(
+                VocabularyItem.builder()
+                        .primaryWord("우주복")
+                        .secondaryWord("bộ đồ phi hành gia")
+                        .primaryDefinition("우주에서 입는 특별한 옷")
+                        .secondaryDefinition("áo đặc biệt")
+                        .audioUrlPrimary("https://example.com/audio.wav")
+                        .build(),
+                VocabularyItem.builder()
+                        .primaryWord("행성")
+                        .secondaryWord("hành tinh")
+                        .primaryDefinition("태양 주위를 도는 천체")
+                        .secondaryDefinition("thiên thể")
+                        .build()
+        );
+
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, vocabulary, "ko", "vi");
+
+        assertThat(tokens).hasSize(2);
+
+        StoryToken first = tokens.get(0);
+        assertThat(first.getText()).isEqualTo("우주복");
+        assertThat(first.getHighlight()).isTrue();
+        assertThat(first.getTranslation()).isEqualTo("bộ đồ phi hành gia");
+        assertThat(first.getDefinition()).isEqualTo("우주에서 입는 특별한 옷");
+        assertThat(first.getSecondaryDefinition()).isEqualTo("áo đặc biệt");
+        assertThat(first.getSourceLanguage()).isEqualTo("ko");
+        assertThat(first.getTargetLanguage()).isEqualTo("vi");
+        assertThat(first.getTokenOrder()).isEqualTo(0);
+        assertThat(first.getAudioUrl()).isEqualTo("https://example.com/audio.wav");
+    }
+
+    @Test
+    @DisplayName("vocabulary null → 빈 리스트 반환")
+    void generateTokens_nullVocabulary_returnsEmpty() {
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, null, "ko", "vi");
+
+        assertThat(tokens).isEmpty();
+    }
+
+    @Test
+    @DisplayName("vocabulary 빈 리스트 → 빈 리스트 반환")
+    void generateTokens_emptyVocabulary_returnsEmpty() {
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, List.of(), "ko", "vi");
+
+        assertThat(tokens).isEmpty();
+    }
+
+    @Test
+    @DisplayName("primaryWord null 또는 blank 항목은 건너뜀")
+    void generateTokens_skipNullOrBlankPrimaryWord() {
+        List<VocabularyItem> vocabulary = List.of(
+                VocabularyItem.builder().primaryWord(null).secondaryWord("test").build(),
+                VocabularyItem.builder().primaryWord("  ").secondaryWord("test").build(),
+                VocabularyItem.builder().primaryWord("우주복").secondaryWord("valid").build()
+        );
+
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, vocabulary, "ko", "vi");
+
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0).getText()).isEqualTo("우주복");
+    }
+
+    @Test
+    @DisplayName("primaryWord 공백 trim 처리")
+    void generateTokens_trimsPrimaryWord() {
+        List<VocabularyItem> vocabulary = List.of(
+                VocabularyItem.builder().primaryWord("  우주복  ").build()
+        );
+
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, vocabulary, "ko", "vi");
+
+        assertThat(tokens.get(0).getText()).isEqualTo("우주복");
+    }
+
+    @Test
+    @DisplayName("tokenOrder는 vocabulary 인덱스 순서로 설정")
+    void generateTokens_tokenOrderMatchesIndex() {
+        List<VocabularyItem> vocabulary = List.of(
+                VocabularyItem.builder().primaryWord("a").build(),
+                VocabularyItem.builder().primaryWord("b").build(),
+                VocabularyItem.builder().primaryWord("c").build()
+        );
+
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, vocabulary, "ko", "vi");
+
+        assertThat(tokens.get(0).getTokenOrder()).isEqualTo(0);
+        assertThat(tokens.get(1).getTokenOrder()).isEqualTo(1);
+        assertThat(tokens.get(2).getTokenOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("audioUrlPrimary null이면 token audioUrl도 null")
+    void generateTokens_nullAudioUrl() {
+        List<VocabularyItem> vocabulary = List.of(
+                VocabularyItem.builder()
+                        .primaryWord("우주복")
+                        .audioUrlPrimary(null)
+                        .build()
+        );
+
+        List<StoryToken> tokens = service.generateTokensForSlide(
+                testSlide, vocabulary, "ko", "vi");
+
+        assertThat(tokens.get(0).getAudioUrl()).isNull();
+    }
+}

--- a/src/test/java/com/moretale/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/moretale/domain/user/service/UserServiceTest.java
@@ -1,0 +1,211 @@
+package com.moretale.domain.user.service;
+
+import com.moretale.domain.honeyjar.entity.HoneyJar;
+import com.moretale.domain.honeyjar.repository.HoneyJarHistoryRepository;
+import com.moretale.domain.honeyjar.repository.HoneyJarRepository;
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.profile.repository.UserProfileRepository;
+import com.moretale.domain.story.dto.RecentStoryResponse;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.user.dto.MyPageResponse;
+import com.moretale.domain.user.dto.UserResponse;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock HoneyJarRepository honeyJarRepository;
+    @Mock HoneyJarHistoryRepository honeyJarHistoryRepository;
+    @Mock StoryRepository storyRepository;
+
+    @InjectMocks UserService userService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L).email("test@example.com")
+                .nickname("홍길동").role(User.Role.USER)
+                .build();
+    }
+
+    // ────────────────── getUserInfo ──────────────────
+
+    @Test
+    @DisplayName("사용자 정보 조회 - 정상")
+    void getUserInfo_success() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        UserResponse response = userService.getUserInfo(1L);
+
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getEmail()).isEqualTo("test@example.com");
+        assertThat(response.getNickname()).isEqualTo("홍길동");
+        assertThat(response.getRole()).isEqualTo("USER");
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회 - 없음 → USER_NOT_FOUND")
+    void getUserInfo_notFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getUserInfo(99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    // ────────────────── getMyPage ──────────────────
+
+    @Test
+    @DisplayName("마이페이지 조회 - 꿀단지 있음")
+    void getMyPage_withHoneyJar() {
+        UserProfile profile = buildProfile();
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(7).totalEarned(10).totalUsed(3).build();
+
+        Story story = buildStory();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findAllByUser_UserId(1L)).willReturn(List.of(profile));
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.of(honeyJar));
+        given(storyRepository.countByUser(testUser)).willReturn(5L);
+        given(storyRepository.findRecentStoriesWithSlides(eq(testUser), any(Pageable.class)))
+                .willReturn(List.of(story));
+
+        MyPageResponse response = userService.getMyPage(1L);
+
+        assertThat(response.getAccountInfo().getEmail()).isEqualTo("test@example.com");
+        assertThat(response.getProfiles()).hasSize(1);
+        assertThat(response.getUsageStatus().getHoneyJarCount()).isEqualTo(7);
+        assertThat(response.getUsageStatus().getCanGenerateFreeStory()).isFalse();
+        assertThat(response.getUsageStatus().getRemainingHoneyJarForFree()).isEqualTo(13);
+        assertThat(response.getUsageStatus().getTotalStoriesCreated()).isEqualTo(5L);
+        assertThat(response.getRecentStories()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("마이페이지 조회 - 신규 사용자 (꿀단지 레코드 없음) → 0 반환")
+    void getMyPage_newUser_noHoneyJar_returnsEmpty() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findAllByUser_UserId(1L)).willReturn(List.of());
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.empty());
+        given(storyRepository.countByUser(testUser)).willReturn(0L);
+        given(storyRepository.findRecentStoriesWithSlides(eq(testUser), any(Pageable.class)))
+                .willReturn(List.of());
+
+        MyPageResponse response = userService.getMyPage(1L);
+
+        assertThat(response.getUsageStatus().getHoneyJarCount()).isEqualTo(0);
+        assertThat(response.getUsageStatus().getCanGenerateFreeStory()).isFalse();
+        assertThat(response.getUsageStatus().getRemainingHoneyJarForFree()).isEqualTo(20);
+        assertThat(response.getRecentStories()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("마이페이지 조회 - 꿀단지 20개 이상 → canGenerateFreeStory = true")
+    void getMyPage_twentyHoneyJars_canGenerateFreeStory() {
+        HoneyJar honeyJar = HoneyJar.builder()
+                .user(testUser).count(20).totalEarned(20).totalUsed(0).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(userProfileRepository.findAllByUser_UserId(1L)).willReturn(List.of());
+        given(honeyJarRepository.findByUser(testUser)).willReturn(Optional.of(honeyJar));
+        given(storyRepository.countByUser(testUser)).willReturn(0L);
+        given(storyRepository.findRecentStoriesWithSlides(eq(testUser), any(Pageable.class)))
+                .willReturn(List.of());
+
+        MyPageResponse response = userService.getMyPage(1L);
+
+        assertThat(response.getUsageStatus().getCanGenerateFreeStory()).isTrue();
+        assertThat(response.getUsageStatus().getRemainingHoneyJarForFree()).isEqualTo(0);
+    }
+
+    // ────────────────── deleteUser ──────────────────
+
+    @Test
+    @DisplayName("회원 탈퇴 - 정상, 순서대로 삭제")
+    void deleteUser_success_correctOrder() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        userService.deleteUser(1L);
+
+        // 순서 검증: 이력 → 꿀단지 → 동화 → 사용자
+        var inOrder = inOrder(
+                honeyJarHistoryRepository, honeyJarRepository,
+                storyRepository, userRepository);
+        inOrder.verify(honeyJarHistoryRepository).deleteAllByUser(testUser);
+        inOrder.verify(honeyJarRepository).deleteByUser(testUser);
+        inOrder.verify(storyRepository).deleteAllByUser(testUser);
+        inOrder.verify(userRepository).delete(testUser);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 - 사용자 없음 → USER_NOT_FOUND")
+    void deleteUser_notFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.deleteUser(99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        verify(honeyJarHistoryRepository, never()).deleteAllByUser(any());
+        verify(userRepository, never()).delete(any());
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private UserProfile buildProfile() {
+        UserProfile p = UserProfile.builder()
+                .profileId(10L).user(testUser).childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6).childAge(5)
+                .firstLanguage(Language.KO).firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI).secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+        p.syncLegacyLanguages();
+        return p;
+    }
+
+    private Story buildStory() {
+        Story story = Story.builder()
+                .storyId(1L).title("흥부와 놀부").user(testUser)
+                .primaryLanguage("ko").secondaryLanguage("vi").isPublic(false).build();
+        story.addSlide(Slide.builder().order(0)
+                .imageUrl("https://example.com/thumb.png").build());
+        return story;
+    }
+}

--- a/src/test/java/com/moretale/domain/vocabulary/service/VocabularyServiceTest.java
+++ b/src/test/java/com/moretale/domain/vocabulary/service/VocabularyServiceTest.java
@@ -1,0 +1,443 @@
+package com.moretale.domain.vocabulary.service;
+
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.story.entity.StoryToken;
+import com.moretale.domain.story.repository.SlideRepository;
+import com.moretale.domain.story.repository.StoryRepository;
+import com.moretale.domain.story.repository.StoryTokenRepository;
+import com.moretale.domain.user.entity.User;
+import com.moretale.domain.user.repository.UserRepository;
+import com.moretale.domain.vocabulary.dto.request.VocabularyCreateRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularyPatchRequest;
+import com.moretale.domain.vocabulary.dto.request.VocabularySearchCondition;
+import com.moretale.domain.vocabulary.dto.response.VocabularyResponse;
+import com.moretale.domain.vocabulary.dto.response.VocabularyStoryResponse;
+import com.moretale.domain.vocabulary.entity.VocabularyEntry;
+import com.moretale.domain.vocabulary.exception.TokenNotFoundException;
+import com.moretale.domain.vocabulary.exception.VocabularyAccessDeniedException;
+import com.moretale.domain.vocabulary.exception.VocabularyDuplicateException;
+import com.moretale.domain.vocabulary.exception.VocabularyNotFoundException;
+import com.moretale.domain.vocabulary.repository.VocabularyEntryRepository;
+import com.moretale.global.exception.BusinessException;
+import com.moretale.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VocabularyService 단위 테스트")
+class VocabularyServiceTest {
+
+    @Mock VocabularyEntryRepository vocabularyEntryRepository;
+    @Mock UserRepository userRepository;
+    @Mock StoryRepository storyRepository;
+    @Mock SlideRepository slideRepository;
+    @Mock StoryTokenRepository storyTokenRepository;
+
+    @InjectMocks VocabularyService vocabularyService;
+
+    private User testUser;
+    private Story testStory;
+    private Slide testSlide;
+    private StoryToken highlightToken;
+    private StoryToken nonHighlightToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder().userId(1L).email("test@example.com").build();
+
+        testStory = Story.builder()
+                .storyId(5L).title("흥부와 놀부")
+                .user(testUser).primaryLanguage("ko").secondaryLanguage("vi").build();
+
+        testSlide = Slide.builder().slideId(10L).story(testStory).order(1).build();
+
+        highlightToken = StoryToken.builder()
+                .tokenId(42L).slide(testSlide)
+                .text("우주복").tokenOrder(0).highlight(true)
+                .translation("bộ đồ phi hành gia")
+                .definition("우주에서 입는 특별한 옷")
+                .secondaryDefinition("áo đặc biệt")
+                .sourceLanguage("ko").targetLanguage("vi")
+                .build();
+
+        nonHighlightToken = StoryToken.builder()
+                .tokenId(43L).slide(testSlide)
+                .text("은").tokenOrder(1).highlight(false)
+                .sourceLanguage("ko").targetLanguage("vi")
+                .build();
+    }
+
+    // ────────────────── save ──────────────────
+
+    @Test
+    @DisplayName("단어 저장 - 정상")
+    void save_success() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findById(5L)).willReturn(Optional.of(testStory));
+        given(slideRepository.findById(10L)).willReturn(Optional.of(testSlide));
+        given(storyTokenRepository.findById(42L)).willReturn(Optional.of(highlightToken));
+        given(vocabularyEntryRepository.existsByUser_UserIdAndStory_StoryIdAndNormalizedWord(
+                1L, 5L, "우주복")).willReturn(false);
+        given(vocabularyEntryRepository.save(any(VocabularyEntry.class)))
+                .willAnswer(inv -> {
+                    VocabularyEntry e = inv.getArgument(0);
+                    return VocabularyEntry.builder()
+                            .vocabularyId(100L)
+                            .user(e.getUser()).story(e.getStory())
+                            .slide(e.getSlide()).storyToken(e.getStoryToken())
+                            .word(e.getWord()).normalizedWord(e.getNormalizedWord())
+                            .translation(e.getTranslation()).definition(e.getDefinition())
+                            .secondaryDefinition(e.getSecondaryDefinition())
+                            .sourceLanguage(e.getSourceLanguage())
+                            .targetLanguage(e.getTargetLanguage())
+                            .isFavorite(false)
+                            .learningStatus(VocabularyEntry.LearningStatus.UNSEEN)
+                            .build();
+                });
+
+        VocabularyCreateRequest request = new VocabularyCreateRequest();
+        setField(request, "tokenId", 42L);
+        setField(request, "slideId", 10L);
+        setField(request, "storyId", 5L);
+
+        VocabularyResponse response = vocabularyService.save(1L, request);
+
+        assertThat(response.getVocabularyId()).isEqualTo(100L);
+        assertThat(response.getWord()).isEqualTo("우주복");
+        assertThat(response.getTranslation()).isEqualTo("bộ đồ phi hành gia");
+        assertThat(response.getNormalizedWord()).isEqualTo("우주복");
+    }
+
+    @Test
+    @DisplayName("단어 저장 - highlight=false 토큰 → INVALID_INPUT_VALUE")
+    void save_nonHighlightToken_throwsException() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findById(5L)).willReturn(Optional.of(testStory));
+        given(slideRepository.findById(10L)).willReturn(Optional.of(testSlide));
+        given(storyTokenRepository.findById(43L)).willReturn(Optional.of(nonHighlightToken));
+
+        VocabularyCreateRequest request = new VocabularyCreateRequest();
+        setField(request, "tokenId", 43L);
+        setField(request, "slideId", 10L);
+        setField(request, "storyId", 5L);
+
+        assertThatThrownBy(() -> vocabularyService.save(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    @Test
+    @DisplayName("단어 저장 - 중복 단어 → VocabularyDuplicateException")
+    void save_duplicate_throws() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findById(5L)).willReturn(Optional.of(testStory));
+        given(slideRepository.findById(10L)).willReturn(Optional.of(testSlide));
+        given(storyTokenRepository.findById(42L)).willReturn(Optional.of(highlightToken));
+        given(vocabularyEntryRepository.existsByUser_UserIdAndStory_StoryIdAndNormalizedWord(
+                1L, 5L, "우주복")).willReturn(true);
+
+        VocabularyCreateRequest request = new VocabularyCreateRequest();
+        setField(request, "tokenId", 42L);
+        setField(request, "slideId", 10L);
+        setField(request, "storyId", 5L);
+
+        assertThatThrownBy(() -> vocabularyService.save(1L, request))
+                .isInstanceOf(VocabularyDuplicateException.class);
+    }
+
+    @Test
+    @DisplayName("단어 저장 - 토큰 없음 → TokenNotFoundException")
+    void save_tokenNotFound() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(storyRepository.findById(5L)).willReturn(Optional.of(testStory));
+        given(slideRepository.findById(10L)).willReturn(Optional.of(testSlide));
+        given(storyTokenRepository.findById(999L)).willReturn(Optional.empty());
+
+        VocabularyCreateRequest request = new VocabularyCreateRequest();
+        setField(request, "tokenId", 999L);
+        setField(request, "slideId", 10L);
+        setField(request, "storyId", 5L);
+
+        assertThatThrownBy(() -> vocabularyService.save(1L, request))
+                .isInstanceOf(TokenNotFoundException.class);
+    }
+
+    // ────────────────── patch ──────────────────
+
+    @Test
+    @DisplayName("즐겨찾기 수정 - false → true")
+    void patch_toggleFavorite() {
+        VocabularyEntry entry = buildEntry(100L, false);
+        given(vocabularyEntryRepository.existsById(100L)).willReturn(true);
+        given(vocabularyEntryRepository.findByVocabularyIdAndUser_UserId(100L, 1L))
+                .willReturn(Optional.of(entry));
+
+        VocabularyPatchRequest request = new VocabularyPatchRequest();
+        setField(request, "isFavorite", true);
+
+        VocabularyResponse response = vocabularyService.patch(1L, 100L, request);
+
+        assertThat(response.getIsFavorite()).isTrue();
+    }
+
+    @Test
+    @DisplayName("학습 상태 수정 - UNSEEN → MASTERED")
+    void patch_learningStatus() {
+        VocabularyEntry entry = buildEntry(100L, false);
+        given(vocabularyEntryRepository.existsById(100L)).willReturn(true);
+        given(vocabularyEntryRepository.findByVocabularyIdAndUser_UserId(100L, 1L))
+                .willReturn(Optional.of(entry));
+
+        VocabularyPatchRequest request = new VocabularyPatchRequest();
+        setField(request, "learningStatus", VocabularyEntry.LearningStatus.MASTERED);
+
+        VocabularyResponse response = vocabularyService.patch(1L, 100L, request);
+
+        assertThat(response.getLearningStatus())
+                .isEqualTo(VocabularyEntry.LearningStatus.MASTERED);
+    }
+
+    @Test
+    @DisplayName("patch - null 필드는 변경 없음")
+    void patch_nullFields_noChange() {
+        VocabularyEntry entry = buildEntry(100L, true);
+        given(vocabularyEntryRepository.existsById(100L)).willReturn(true);
+        given(vocabularyEntryRepository.findByVocabularyIdAndUser_UserId(100L, 1L))
+                .willReturn(Optional.of(entry));
+
+        // 모든 필드 null → 변경 없음
+        VocabularyPatchRequest request = new VocabularyPatchRequest();
+
+        VocabularyResponse response = vocabularyService.patch(1L, 100L, request);
+
+        assertThat(response.getIsFavorite()).isTrue(); // 기존값 유지
+    }
+
+    @Test
+    @DisplayName("patch - 항목 없음 → VocabularyNotFoundException")
+    void patch_notFound() {
+        given(vocabularyEntryRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() ->
+                vocabularyService.patch(1L, 999L, new VocabularyPatchRequest()))
+                .isInstanceOf(VocabularyNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("patch - 타인 소유 항목 → VocabularyAccessDeniedException")
+    void patch_accessDenied() {
+        given(vocabularyEntryRepository.existsById(100L)).willReturn(true);
+        given(vocabularyEntryRepository.findByVocabularyIdAndUser_UserId(100L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                vocabularyService.patch(1L, 100L, new VocabularyPatchRequest()))
+                .isInstanceOf(VocabularyAccessDeniedException.class);
+    }
+
+    // ────────────────── delete ──────────────────
+
+    @Test
+    @DisplayName("단어 삭제 - 정상")
+    void delete_success() {
+        VocabularyEntry entry = buildEntry(100L, false);
+        given(vocabularyEntryRepository.existsById(100L)).willReturn(true);
+        given(vocabularyEntryRepository.findByVocabularyIdAndUser_UserId(100L, 1L))
+                .willReturn(Optional.of(entry));
+
+        vocabularyService.delete(1L, 100L);
+
+        verify(vocabularyEntryRepository).delete(entry);
+    }
+
+    // ────────────────── getStoriesWithVocabulary ──────────────────
+
+    @Test
+    @DisplayName("단어 저장 동화 목록 - 단어 수 포함 반환")
+    void getStoriesWithVocabulary_withWordCount() {
+        given(vocabularyEntryRepository.findDistinctStoriesByUserId(1L))
+                .willReturn(List.of(testStory));
+        given(vocabularyEntryRepository.countByUser_UserIdAndStory_StoryId(1L, 5L))
+                .willReturn(3L);
+
+        List<VocabularyStoryResponse> result =
+                vocabularyService.getStoriesWithVocabulary(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStoryId()).isEqualTo(5L);
+        assertThat(result.get(0).getWordCount()).isEqualTo(3L);
+    }
+
+    // ────────────────── getWithFilters - 즐겨찾기 정렬 선행 정책 ──────────────────
+
+    @Test
+    @DisplayName("getWithFilters - favorite 필터 없으면 isFavorite DESC 선행 정렬 적용")
+    void getWithFilters_noFavoriteFilter_prependsFavoriteSort() {
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        condition.setFavorite(null);
+
+        Pageable pageable = PageRequest.of(0, 20,
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        given(vocabularyEntryRepository.findIdsByFilters(
+                eq(1L), isNull(), isNull(), isNull(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        vocabularyService.getWithFilters(1L, condition, pageable);
+
+        verify(vocabularyEntryRepository).findIdsByFilters(
+                eq(1L), isNull(), isNull(), isNull(),
+                argThat(p -> {
+                    Sort sort = p.getSort();
+                    List<Sort.Order> orders = sort.toList();
+                    // isFavorite DESC가 첫 번째여야 함
+                    return orders.size() >= 2
+                            && orders.get(0).getProperty().equals("isFavorite")
+                            && orders.get(0).getDirection() == Sort.Direction.DESC
+                            && orders.get(1).getProperty().equals("createdAt");
+                })
+        );
+    }
+
+    @Test
+    @DisplayName("getWithFilters - favorite=true 필터 시 isFavorite 선행 정렬 생략")
+    void getWithFilters_favoriteFilter_skipsFavoriteSort() {
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        condition.setFavorite(true);
+
+        Pageable pageable = PageRequest.of(0, 20,
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        given(vocabularyEntryRepository.findIdsByFilters(
+                eq(1L), isNull(), eq(true), isNull(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        vocabularyService.getWithFilters(1L, condition, pageable);
+
+        verify(vocabularyEntryRepository).findIdsByFilters(
+                eq(1L), isNull(), eq(true), isNull(),
+                argThat(p -> {
+                    Sort sort = p.getSort();
+                    List<Sort.Order> orders = sort.toList();
+                    // isFavorite 정렬이 없어야 함
+                    return orders.stream()
+                            .noneMatch(o -> o.getProperty().equals("isFavorite"));
+                })
+        );
+    }
+
+    @Test
+    @DisplayName("getWithFilters - keyword 있으면 LIKE 패턴으로 변환")
+    void getWithFilters_withKeyword_convertsToLikePattern() {
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        condition.setKeyword("사자");
+
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(vocabularyEntryRepository.findIdsByFilters(
+                eq(1L), isNull(), isNull(), eq("%사자%"), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        vocabularyService.getWithFilters(1L, condition, pageable);
+
+        verify(vocabularyEntryRepository).findIdsByFilters(
+                eq(1L), isNull(), isNull(), eq("%사자%"), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("getWithFilters - keyword null이면 null 그대로 전달")
+    void getWithFilters_nullKeyword_passesNull() {
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        condition.setKeyword(null);
+
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(vocabularyEntryRepository.findIdsByFilters(
+                eq(1L), isNull(), isNull(), isNull(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        vocabularyService.getWithFilters(1L, condition, pageable);
+
+        verify(vocabularyEntryRepository).findIdsByFilters(
+                eq(1L), isNull(), isNull(), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("getWithFilters - 2단계 조회 후 원래 ID 순서 유지")
+    void getWithFilters_preservesOrder() {
+        VocabularySearchCondition condition = new VocabularySearchCondition();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<Long> idPage = new PageImpl<>(List.of(1L, 2L, 3L), pageable, 3);
+
+        VocabularyEntry e1 = buildEntry(1L, false);
+        VocabularyEntry e2 = buildEntry(2L, true);
+        VocabularyEntry e3 = buildEntry(3L, false);
+
+        given(vocabularyEntryRepository.findIdsByFilters(
+                eq(1L), isNull(), isNull(), isNull(), any(Pageable.class)))
+                .willReturn(idPage);
+        // DB에서 역순 반환
+        given(vocabularyEntryRepository.fetchByIds(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(e3, e1, e2));
+
+        Page<VocabularyResponse> result =
+                vocabularyService.getWithFilters(1L, condition, pageable);
+
+        assertThat(result.getContent().get(0).getVocabularyId()).isEqualTo(1L);
+        assertThat(result.getContent().get(1).getVocabularyId()).isEqualTo(2L);
+        assertThat(result.getContent().get(2).getVocabularyId()).isEqualTo(3L);
+    }
+
+    // ────────────────── 헬퍼 ──────────────────
+
+    private VocabularyEntry buildEntry(Long id, boolean isFavorite) {
+        return VocabularyEntry.builder()
+                .vocabularyId(id)
+                .user(testUser)
+                .story(testStory)
+                .slide(testSlide)
+                .storyToken(highlightToken)
+                .word("우주복")
+                .normalizedWord("우주복")
+                .translation("bộ đồ phi hành gia")
+                .definition("우주에서 입는 특별한 옷")
+                .secondaryDefinition("áo đặc biệt")
+                .sourceLanguage("ko")
+                .targetLanguage("vi")
+                .isFavorite(isFavorite)
+                .learningStatus(VocabularyEntry.LearningStatus.UNSEEN)
+                .build();
+    }
+
+    @SuppressWarnings("all")
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/moretale/support/IntegrationTestSupport.java
+++ b/src/test/java/com/moretale/support/IntegrationTestSupport.java
@@ -1,0 +1,27 @@
+package com.moretale.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 통합 테스트 공통 기반 클래스
+ * - H2 인메모리 DB 사용 (test 프로파일)
+ * - @Transactional: 각 테스트 후 DB 롤백
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+public abstract class IntegrationTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+}

--- a/src/test/java/com/moretale/support/TestFixture.java
+++ b/src/test/java/com/moretale/support/TestFixture.java
@@ -1,0 +1,74 @@
+package com.moretale.support;
+
+import com.moretale.domain.profile.entity.*;
+import com.moretale.domain.story.entity.Slide;
+import com.moretale.domain.story.entity.Story;
+import com.moretale.domain.user.entity.User;
+
+// 통합 테스트용 공통 픽스처 팩토리
+public class TestFixture {
+
+    public static User createUser(String email) {
+        return User.builder()
+                .email(email)
+                .nickname("테스트유저")
+                .role(User.Role.USER)
+                .provider("google")
+                .providerId("google-" + email)
+                .build();
+    }
+
+    public static UserProfile createProfile(User user) {
+        UserProfile profile = UserProfile.builder()
+                .user(user)
+                .childName("민준")
+                .ageGroup(AgeGroup.AGE_5_6)
+                .childAge(5)
+                .firstLanguage(Language.KO)
+                .customFirstLanguage(null)
+                .firstLanguageProficiency(LanguageProficiency.BEE)
+                .secondLanguage(Language.VI)
+                .customSecondLanguage(null)
+                .secondLanguageProficiency(LanguageProficiency.LARVA)
+                .firstLanguageListening(LanguageProficiency.BEE)
+                .firstLanguageSpeaking(LanguageProficiency.PUPA)
+                .secondLanguageListening(LanguageProficiency.LARVA)
+                .secondLanguageSpeaking(LanguageProficiency.EGG)
+                .familyStructure(FamilyStructure.TWO_PARENTS)
+                .storyPreference(StoryPreference.FUN_ADVENTURE)
+                .build();
+        profile.syncLegacyLanguages();
+        return profile;
+    }
+
+    public static Story createStory(User user, UserProfile profile, String title) {
+        return Story.builder()
+                .title(title)
+                .prompt("테스트 프롬프트")
+                .user(user)
+                .profile(profile)
+                .childName(profile.getChildName())
+                .primaryLanguage("ko")
+                .secondaryLanguage("vi")
+                .isPublic(false)
+                .build();
+    }
+
+    public static Slide createCoverSlide(String imageUrl) {
+        return Slide.builder()
+                .order(0)
+                .imageUrl(imageUrl)
+                .textKr("")
+                .textNative("")
+                .build();
+    }
+
+    public static Slide createContentSlide(int order, String textKr, String textNative) {
+        return Slide.builder()
+                .order(order)
+                .imageUrl("https://example.com/slide" + order + ".png")
+                .textKr(textKr)
+                .textNative(textNative)
+                .build();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,63 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        default_batch_fetch_size: 100
+
+  sql:
+    init:
+      mode: never
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-client-id
+            client-secret: test-client-secret
+
+jwt:
+  secret: test-secret-key-must-be-at-least-64-characters-long-for-hs512-algorithm
+  expiration: 86400000
+
+app:
+  frontend-url: http://localhost:3000
+
+file:
+  upload:
+    base-path: /tmp/moretale-test
+    base-url: http://localhost:8080/uploads
+
+tts:
+  storage:
+    path: tts/audio
+
+moretale:
+  ai:
+    base-url: http://localhost:9999
+    api-key: test-key
+    callback-base-url: http://localhost:8080
+  cors:
+    allowed-origins: http://localhost:3000
+
+google:
+  cloud:
+    credentials:
+      location: classpath:gcp-service-account-test.json
+    storage:
+      bucket: test-bucket
+
+logging:
+  level:
+    root: warn
+    com.moretale: info

--- a/src/test/resources/gcp-service-account-test.json
+++ b/src/test/resources/gcp-service-account-test.json
@@ -1,0 +1,10 @@
+{
+  "type": "service_account",
+  "project_id": "test-project",
+  "private_key_id": "test-key-id",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0Z3VS5JJcds3xHn/ygWep4OF7+ZXgFYMBECkF5vEJSl9mV5+\ntest-placeholder\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "test@test-project.iam.gserviceaccount.com",
+  "client_id": "123456789",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #35
- close #36
- close #37

## ✨ 작업 내용 요약
- Validation 테스트 추가
  - `OnboardingProfileRequest`
  - `UserProfileRequest`
  - `LanguageUpdateRequest`
- Service 레이어 테스트 추가
  - `UserProfileService`
  - `StoryService`
  - `HoneyJarService`
  - `QuizService`
  - `VocabularyService`
  - `UserService`
- Controller 통합 테스트 추가
  - `UserProfileController`
  - `StoryController`
  - `LibraryController`
  - `QuizController`
- 테스트 지원 환경 구성
  - H2 인메모리 DB 적용
  - Mockito 의존성 추가
  - `application-test.yml` 추가
  - `IntegrationTestSupport` 및 `TestFixture` 작성
- GitHub Actions 배포 브랜치를 `develop` → `main`으로 변경
- README 폴더 구조 최신화

## 🗒️ 참고 사항
- 테스트는 H2 기반 `test` 프로파일에서 실행
- Google Cloud 서비스 계정은 테스트용 더미 설정 파일을 사용
- 전체 테스트 통과 확인 완료 (`219 tests, 0 failures, 0 ignored`)